### PR TITLE
Feature/dialogs style namings

### DIFF
--- a/libraries/dialogs/README.md
+++ b/libraries/dialogs/README.md
@@ -1,7 +1,7 @@
 
-<img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-1.png" width="240"/><img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-2.png" width="240"/>  
+<img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-1.png" width="240"/> <img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-2.png" width="240"/>
   
-[![](https://jitpack.io/v/Trendyol/android-ui-components.svg)](https://jitpack.io/#Trendyol/android-ui-components) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)  
+$dialogsVersion = dialogs-1.0.1 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
   
 ## Dialogs  
 Dialogs is a bunch of BottomSheetDialogs to use in app to show user an information, agreement or list.  
@@ -33,7 +33,7 @@ Simple dialog to show information, error or text.
 | ------------- |-------------|-------------| ------------- |  
 | `title` | String |Title of the dialog | "" |  
 |  `showCloseButton` | Boolean | Close button visibility | false |  
-| `closeButtonListener` | (Dialog) -> Unit |Listener for close button. When clicked, dialog will dismiss and listener vill be invoked with dialog. | { } |
+| `closeButtonListener` | (Dialog) -> Unit |Listener for close button. When clicked, dialog will dismiss and listener will be invoked with dialog. | { } |
 | `content` | CharSequence | Content of a dialog | "" |
 | `showContentAsHtml` | Boolean | If you provided `content` as Html and set this flag as true, content will be parsed as HTML. | false |
 | `contentImage` | Int | Drawable resource id of an visual, will be shown on top of `content` | 0 |

--- a/libraries/dialogs/build.gradle
+++ b/libraries/dialogs/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'com.github.dcendents.android-maven'
 
 group="com.trendyol.ui-components"
-version="1.0.0"
+version="1.0.1"
 
 android {
     compileSdkVersion 29

--- a/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/BaseBottomSheetDialog.kt
+++ b/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/BaseBottomSheetDialog.kt
@@ -23,7 +23,7 @@ abstract class BaseBottomSheetDialog<DB : ViewDataBinding> : BottomSheetDialogFr
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setStyle(STYLE_NO_FRAME, R.style.BottomSheetDialogStyle)
+        setStyle(STYLE_NO_FRAME, R.style.Trendyol_UIComponents_Dialogs_BottomSheetDialogStyle)
     }
 
     override fun onCreateView(

--- a/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragment.kt
+++ b/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragment.kt
@@ -23,11 +23,11 @@ class DialogFragment internal constructor(
 
     override fun setUpView() {
         with(binding) {
-            binding.imageClose.setOnClickListener {
+            imageClose.setOnClickListener {
                 dismiss()
                 closeButtonListener?.invoke(this@DialogFragment)
             }
-            binding.buttonLeft.setOnClickListener {
+            buttonLeft.setOnClickListener {
                 leftButtonClickListener?.invoke(this@DialogFragment)
             }
             buttonRight.setOnClickListener {

--- a/libraries/dialogs/src/main/res/layout/fragment_dialog.xml
+++ b/libraries/dialogs/src/main/res/layout/fragment_dialog.xml
@@ -11,10 +11,9 @@
     </data>
 
     <com.google.android.material.card.MaterialCardView
-        style="@style/PrimaryCard"
+        style="@style/Trendyol.UIComponents.Dialogs.PrimaryCard"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
+        android:layout_height="wrap_content">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
@@ -46,7 +45,7 @@
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/textTitle"
-                style="@style/PrimaryText.Title"
+                style="@style/Trendyol.UIComponents.Dialogs.PrimaryText.Title"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:text="@{viewState.title}"
@@ -84,7 +83,7 @@
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/textContent"
-                style="@style/PrimaryText.Body"
+                style="@style/Trendyol.UIComponents.Dialogs.PrimaryText.Body"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:padding="@dimen/margin_dialog_outer"
@@ -109,6 +108,7 @@
                 app:layout_constraintTop_toBottomOf="@id/textContent"
                 tools:text="Cancel"
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:textAllCaps="false"
                 app:strokeColor="?attr/colorAccent"/>
 
             <com.google.android.material.button.MaterialButton
@@ -124,7 +124,8 @@
                 app:layout_constraintEnd_toEndOf="@id/guideEnd"
                 app:layout_constraintStart_toEndOf="@id/buttonLeft"
                 app:layout_constraintTop_toBottomOf="@id/textContent"
-                tools:text="OK"
+                android:textAllCaps="false"
+                tools:text="Ok"
                 android:visibility="visible"/>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.card.MaterialCardView>

--- a/libraries/dialogs/src/main/res/values/styles.xml
+++ b/libraries/dialogs/src/main/res/values/styles.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="BottomSheetStyle" parent="@style/Widget.Design.BottomSheet.Modal">
-        <item name="android:background">@android:color/transparent</item>
-    </style>
-
-    <style name="BottomSheetDialogStyle" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
+    <style name="Trendyol.UIComponents.Dialogs.BottomSheetDialogStyle" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:colorBackground">@android:color/transparent</item>
@@ -17,23 +13,23 @@
         <item name="state_collapsed">true</item>
     </style>
 
-    <style name="PrimaryCard" parent="Widget.MaterialComponents.CardView">
+    <style name="Trendyol.UIComponents.Dialogs.PrimaryCard" parent="Widget.MaterialComponents.CardView">
         <item name="cardCornerRadius">16dp</item>
         <item name="cardElevation">2dp</item>
         <item name="layout_behavior">android.support.design.widget.BottomSheetBehavior</item>
     </style>
 
-    <style name="PrimaryText" parent="TextAppearance.AppCompat.Body1">
+    <style name="Trendyol.UIComponents.Dialogs.PrimaryText" parent="TextAppearance.AppCompat.Body1">
         <item name="android:fontFamily">sans-serif</item>
         <item name="android:textColor">#333333</item>
     </style>
 
-    <style name="PrimaryText.Title">
+    <style name="Trendyol.UIComponents.Dialogs.PrimaryText.Title">
         <item name="android:fontFamily">sans-serif-medium</item>
         <item name="android:textSize">14sp</item>
     </style>
 
-    <style name="PrimaryText.Body">
+    <style name="Trendyol.UIComponents.Dialogs.PrimaryText.Body">
         <item name="android:textColor">#666666</item>
         <item name="android:textSize">14sp</item>
     </style>

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "29.0.1"
+    buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "com.trendyol.uicomponents"
         minSdkVersion 17

--- a/sample/src/main/java/com/trendyol/uicomponents/DialogsActivity.kt
+++ b/sample/src/main/java/com/trendyol/uicomponents/DialogsActivity.kt
@@ -27,12 +27,12 @@ class DialogsActivity : AppCompatActivity() {
             showCloseButton = true
             closeButtonListener = { showToast("Info dailog closed.") }
             content = SpannableString.valueOf(getSpannableString())
-            contentImage = android.R.drawable.btn_plus
+            contentImage = R.mipmap.ic_launcher_round
         }.showDialog(supportFragmentManager)
     }
 
     private fun showAgreementDialog() {
-        agreementDialog {
+        val dialog = agreementDialog {
             title = "Agreement Dialog Sample"
             leftButtonText = "Cancel"
             rightButtonText = "Agree"
@@ -46,7 +46,9 @@ class DialogsActivity : AppCompatActivity() {
                 it.dismiss()
                 showToast("Left buttonClicked")
             }
-        }.showDialog(supportFragmentManager)
+        }
+
+        dialog.showDialog(supportFragmentManager)
     }
 
     private fun getSpannableString(): SpannableStringBuilder =

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>


### PR DESCRIPTION
Fix style naming overrides.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Style namings are updated. _"Trendyol.UIComponents.Dialogs."_  prefix added.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested on real device with Android 7.1, also tested on emulator with Android 10.

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
