### PR TITLE
Bug fix/configuration change

### DIFF
--- a/libraries/dialogs/README.md
+++ b/libraries/dialogs/README.md
@@ -24,7 +24,9 @@ dependencies {
 You can configure your dialog with given extensions with Kotlin DSL syntax.
 
 To show the dialog you just need to call `showDialog(FragmentManager)` function.
-  
+
+You can call DialogFragment.findFragment(supportFragmentManager) method inorder to retrieve DialogFragment's instance and use that instance to set click listeners after configuration change. 
+
 * Info Dialog:
 
 Simple dialog to show information, error or text.
@@ -130,6 +132,8 @@ selectionDialog {
     * Implement multiple selectable type.
 * Provide theme for more styling.
 * Update builder for Java.
+* ~~Stop using DialogFragment's constructor inorder to build DialogFragment~~
+
 
 ## Contributors
 This library is maintained mainly by Trendyol Android Team members but also other Android lovers contributes.

--- a/libraries/dialogs/build.gradle
+++ b/libraries/dialogs/build.gradle
@@ -31,6 +31,10 @@ android {
     dataBinding {
         enabled true
     }
+
+    androidExtensions {
+        experimental = true
+    }
 }
 
 dependencies {

--- a/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/Builder.kt
+++ b/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/Builder.kt
@@ -19,16 +19,22 @@ open class InfoDialogBuilder internal constructor() : Builder() {
 
     internal fun buildInfoDialog(block: InfoDialogBuilder.() -> Unit): DialogFragment {
         return InfoDialogBuilder().apply(block).let {
-            DialogFragment(
-                title = it.title,
-                showCloseButton = it.showCloseButton,
-                closeButtonListener = it.closeButtonListener ?: { },
-                content = SpannableString(it.content),
-                contentImage = it.contentImage,
-                showContentAsHtml = it.showContentAsHtml
-            )
+            DialogFragment().apply {
+                arguments = DialogFragmentArguments(
+                    title = it.title,
+                    showCloseButton = it.showCloseButton,
+                    content = SpannableString(it.content),
+                    contentImage = it.contentImage,
+                    showContentAsHtml = it.showContentAsHtml
+                ).toBundle()
+                this.closeButtonListener = it.closeButtonListener ?: { }
+            }
         }
     }
+}
+
+class ClickEvent() {
+
 }
 
 open class AgreementDialogBuilder internal constructor() : InfoDialogBuilder() {
@@ -40,18 +46,20 @@ open class AgreementDialogBuilder internal constructor() : InfoDialogBuilder() {
 
     internal fun buildAgreementDialog(block: AgreementDialogBuilder.() -> Unit): DialogFragment =
         AgreementDialogBuilder().apply(block).let {
-            DialogFragment(
-                title = it.title,
-                showCloseButton = it.showCloseButton,
-                closeButtonListener = it.closeButtonListener,
-                content = SpannableString(it.content),
-                showContentAsHtml = it.showContentAsHtml,
-                contentImage = it.contentImage,
-                rightButtonText = it.rightButtonText,
-                leftButtonText = it.leftButtonText,
-                rightButtonClickListener = it.rightButtonClickListener,
+            DialogFragment().apply {
+                arguments = DialogFragmentArguments(
+                    title = it.title,
+                    showCloseButton = it.showCloseButton,
+                    content = SpannableString(it.content),
+                    showContentAsHtml = it.showContentAsHtml,
+                    contentImage = it.contentImage,
+                    rightButtonText = it.rightButtonText,
+                    leftButtonText = it.leftButtonText
+                ).toBundle()
+                closeButtonListener = it.closeButtonListener
+                rightButtonClickListener = it.rightButtonClickListener
                 leftButtonClickListener = it.leftButtonClickListener
-            )
+            }
         }
 }
 
@@ -66,19 +74,22 @@ class SelectionDialogBuilder internal constructor() : InfoDialogBuilder() {
 
     internal fun buildSelectionDialog(block: SelectionDialogBuilder.() -> Unit): DialogFragment =
         SelectionDialogBuilder().apply(block).let {
-            DialogFragment(
-                title = it.title,
-                showCloseButton = it.showCloseButton,
-                closeButtonListener = it.closeButtonListener,
-                content = SpannableString(it.content),
-                showContentAsHtml = it.showContentAsHtml,
-                contentImage = it.contentImage,
-                items = it.items,
-                showItemsAsHtml = it.showItemsAsHtml,
-                onItemSelectedListener = it.onItemSelectedListener,
-                enableSearch = it.enableSearch,
-                showClearSearchButton = it.showClearSearchButton,
-                searchHint = it.searchHint
-            )
+            DialogFragment().apply {
+                arguments = DialogFragmentArguments(
+                    title = it.title,
+                    showCloseButton = it.showCloseButton,
+                    content = SpannableString(it.content),
+                    showContentAsHtml = it.showContentAsHtml,
+                    contentImage = it.contentImage,
+                    items = it.items,
+                    showItemsAsHtml = it.showItemsAsHtml,
+                    enableSearch = it.enableSearch,
+                    showClearSearchButton = it.showClearSearchButton,
+                    searchHint = it.searchHint
+                ).toBundle()
+                closeButtonListener = it.closeButtonListener
+                onItemSelectedListener = it.onItemSelectedListener
+            }
+
         }
 }

--- a/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragment.kt
+++ b/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragment.kt
@@ -86,7 +86,7 @@ class DialogFragment internal constructor() : BaseBottomSheetDialog<FragmentDial
             contentImage = dialogArguments.contentImage,
             leftButtonText = dialogArguments.leftButtonText,
             rightButtonText = dialogArguments.rightButtonText,
-            isListVisible = dialogArguments.items != null,
+            isListVisible = dialogArguments.items?.isNotEmpty() == true,
             isSearchEnabled = dialogArguments.enableSearch,
             isClearSearchButtonVisible = dialogArguments.showClearSearchButton,
             searchHint = dialogArguments.searchHint

--- a/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragment.kt
+++ b/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragment.kt
@@ -2,7 +2,6 @@ package com.trendyol.uicomponents.dialogs
 
 import android.text.SpannableString
 import android.view.ViewGroup.FOCUS_AFTER_DESCENDANTS
-import androidx.annotation.DrawableRes
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Observer
@@ -13,35 +12,27 @@ import com.trendyol.dialog.databinding.FragmentDialogBinding
 import com.trendyol.uicomponents.dialogs.list.DialogListAdapter
 import com.trendyol.uicomponents.dialogs.list.DialogListViewModel
 
-class DialogFragment internal constructor(
-    private val title: String? = null,
-    private val showCloseButton: Boolean? = null,
-    private val closeButtonListener: ((DialogFragment) -> Unit)? = null,
-    private val content: CharSequence? = null,
-    private val showContentAsHtml: Boolean = false,
-    @DrawableRes private val contentImage: Int? = null,
-    private val leftButtonText: String? = null,
-    private val rightButtonText: String? = null,
-    private val leftButtonClickListener: ((DialogFragment) -> Unit)? = null,
-    private val rightButtonClickListener: ((DialogFragment) -> Unit)? = null,
-    private val items: List<Pair<Boolean, CharSequence>>? = null,
-    private val showItemsAsHtml: Boolean = false,
-    private val onItemSelectedListener: ((DialogFragment, Int) -> Unit)? = null,
-    private val enableSearch: Boolean = false,
-    private val showClearSearchButton: Boolean = false,
-    private val searchHint: String = ""
-) : BaseBottomSheetDialog<FragmentDialogBinding>() {
+class DialogFragment internal constructor() : BaseBottomSheetDialog<FragmentDialogBinding>() {
 
-    private val itemsAdapter by lazy { DialogListAdapter(showItemsAsHtml) }
+    private val dialogArguments by lazy(LazyThreadSafetyMode.NONE)
+    { requireNotNull(DialogFragmentArguments.fromBundle(requireArguments())) }
+
+    private val itemsAdapter by lazy(LazyThreadSafetyMode.NONE) { DialogListAdapter(dialogArguments.showItemsAsHtml) }
+
     private val dialogListViewModel by lazy {
         ViewModelProviders.of(this)[DialogListViewModel::class.java]
     }
+
+    var closeButtonListener: ((DialogFragment) -> Unit)? = null
+    var leftButtonClickListener: ((DialogFragment) -> Unit)? = null
+    var rightButtonClickListener: ((DialogFragment) -> Unit)? = null
+    var onItemSelectedListener: ((DialogFragment, Int) -> Unit)? = null
 
     override fun getLayoutResId(): Int = R.layout.fragment_dialog
 
     override fun setUpView() {
         animateCornerRadiusWithStateChanged()
-        
+
         with(binding) {
             imageClose.setOnClickListener {
                 dismiss()
@@ -54,14 +45,8 @@ class DialogFragment internal constructor(
                 rightButtonClickListener?.invoke(this@DialogFragment)
             }
 
-            if (items != null) {
-                recyclerViewItems.adapter = itemsAdapter
-                recyclerViewItems.isNestedScrollingEnabled = false
-
-                itemsAdapter.onItemSelectedListener = { position ->
-                    dialogListViewModel.onSelectionChanged(position)
-                }
-
+            dialogArguments.items?.let { items ->
+                initializeRecyclerView()
                 editTextSearch.setOnFocusChangeListener { _, hasFocus ->
                     if (hasFocus) {
                         setBottomSheetState(BottomSheetBehavior.STATE_EXPANDED)
@@ -84,19 +69,27 @@ class DialogFragment internal constructor(
         }
     }
 
+    private fun initializeRecyclerView() = with(binding.recyclerViewItems) {
+        adapter = itemsAdapter.apply {
+            onItemSelectedListener =
+                { position -> dialogListViewModel.onSelectionChanged(position) }
+        }
+        isNestedScrollingEnabled = false
+    }
+
     override fun setViewState() {
         val viewState = DialogViewState(
-            title = title,
-            showCloseButton = showCloseButton,
-            content = content ?: SpannableString(""),
-            showContentAsHtml = showContentAsHtml,
-            contentImage = contentImage,
-            leftButtonText = leftButtonText,
-            rightButtonText = rightButtonText,
-            isListVisible = items != null,
-            isSearchEnabled = enableSearch,
-            isClearSearchButtonVisible = showClearSearchButton,
-            searchHint = searchHint
+            title = dialogArguments.title,
+            showCloseButton = dialogArguments.showCloseButton,
+            content = dialogArguments.content ?: SpannableString(""),
+            showContentAsHtml = dialogArguments.showContentAsHtml,
+            contentImage = dialogArguments.contentImage,
+            leftButtonText = dialogArguments.leftButtonText,
+            rightButtonText = dialogArguments.rightButtonText,
+            isListVisible = dialogArguments.items != null,
+            isSearchEnabled = dialogArguments.enableSearch,
+            isClearSearchButtonVisible = dialogArguments.showClearSearchButton,
+            searchHint = dialogArguments.searchHint
         )
 
         binding.viewState = viewState
@@ -122,5 +115,9 @@ class DialogFragment internal constructor(
     companion object {
 
         const val TAG: String = "TRENDYOL_BOTTOM_SHEET_DIALOG"
+
+        fun findFragment(fragmentManager: FragmentManager): DialogFragment? {
+            return fragmentManager.findFragmentByTag(TAG) as? DialogFragment
+        }
     }
 }

--- a/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragmentArguments.kt
+++ b/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragmentArguments.kt
@@ -1,0 +1,31 @@
+package com.trendyol.uicomponents.dialogs
+
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.annotation.DrawableRes
+import androidx.core.os.bundleOf
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+class DialogFragmentArguments(
+    val title: String? = null,
+    val showCloseButton: Boolean? = null,
+    val content: CharSequence? = null,
+    val showContentAsHtml: Boolean = false,
+    @DrawableRes val contentImage: Int? = null,
+    val leftButtonText: String? = null,
+    val rightButtonText: String? = null,
+    val items: List<Pair<Boolean, CharSequence>>? = null,
+    val showItemsAsHtml: Boolean = false,
+    val enableSearch: Boolean = false,
+    val showClearSearchButton: Boolean = false,
+    val searchHint: String = ""
+) : Parcelable {
+
+    fun toBundle() = bundleOf("ARGUMENTS" to this)
+
+    companion object {
+        fun fromBundle(bundle: Bundle) = bundle
+            .getParcelable<DialogFragmentArguments>("ARGUMENTS")
+    }
+}

--- a/sample/src/main/java/com/trendyol/uicomponents/DialogsActivity.kt
+++ b/sample/src/main/java/com/trendyol/uicomponents/DialogsActivity.kt
@@ -7,6 +7,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.text.bold
 import androidx.core.text.color
+import com.trendyol.uicomponents.dialogs.DialogFragment
 import com.trendyol.uicomponents.dialogs.agreementDialog
 import com.trendyol.uicomponents.dialogs.infoDialog
 import com.trendyol.uicomponents.dialogs.selectionDialog
@@ -24,11 +25,28 @@ class DialogsActivity : AppCompatActivity() {
         button_selection_with_search_dialog.setOnClickListener { showSelectionWithSearchDialog() }
     }
 
+    private val infoDialogClosed: (DialogFragment) -> Unit = { showToast("Info dailog closed.") }
+
+    private val rightButtonClickListener: (DialogFragment) -> Unit = {
+        it.dismiss()
+        showToast("Right button clicked.")
+    }
+
+    private val leftButtonClickListener: (DialogFragment) -> Unit = {
+        it.dismiss()
+        showToast("Left buttonClicked")
+    }
+
+    private val onItemSelectedListener: (DialogFragment, Int) -> Unit =
+        { dialogFragment, position ->
+            showToast("Selection changed to ${position + 1}th ")
+        }
+
     private fun showInfoDialog() {
         infoDialog {
             title = "Info Dialog Sample"
             showCloseButton = true
-            closeButtonListener = { showToast("Info dailog closed.") }
+            closeButtonListener = infoDialogClosed
             content = SpannableString.valueOf(getSpannableString())
             contentImage = R.mipmap.ic_launcher_round
         }.showDialog(supportFragmentManager)
@@ -41,14 +59,8 @@ class DialogsActivity : AppCompatActivity() {
             rightButtonText = "Agree"
             content = getHtmlString()
             showContentAsHtml = true
-            rightButtonClickListener = {
-                it.dismiss()
-                showToast("Right button clicked.")
-            }
-            leftButtonClickListener = {
-                it.dismiss()
-                showToast("Left buttonClicked")
-            }
+            rightButtonClickListener = this@DialogsActivity.rightButtonClickListener
+            leftButtonClickListener = this@DialogsActivity.leftButtonClickListener
         }
 
         agreementDialog.showDialog(supportFragmentManager)
@@ -63,10 +75,7 @@ class DialogsActivity : AppCompatActivity() {
             contentImage = android.R.drawable.ic_dialog_email
             items = getListItems()
             showItemsAsHtml = false
-            onItemSelectedListener = { dialogFragment, i ->
-                dialogFragment.dismiss()
-                showToast("Selection changed to ${i + 1}th ")
-            }
+            onItemSelectedListener = this@DialogsActivity.onItemSelectedListener
         }
 
         selectionDialog.showDialog(supportFragmentManager)
@@ -80,14 +89,28 @@ class DialogsActivity : AppCompatActivity() {
             showCloseButton = false
             contentImage = android.R.drawable.ic_dialog_email
             items = getListItems()
-            onItemSelectedListener = { dialogFragment, i ->
-                showToast("Selection changed to ${i + 1}th ")
-            }
+            onItemSelectedListener = this@DialogsActivity.onItemSelectedListener
             enableSearch = true
             showClearSearchButton = true
             searchHint = "Hint for search"
         }.showDialog(supportFragmentManager)
     }
+
+    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
+        super.onRestoreInstanceState(savedInstanceState)
+        setDialogFragmentListenersIfNecessary()
+    }
+
+    private fun setDialogFragmentListenersIfNecessary() =
+        DialogFragment
+            .findFragment(supportFragmentManager)
+            ?.apply {
+                rightButtonClickListener = this@DialogsActivity.rightButtonClickListener
+                leftButtonClickListener = this@DialogsActivity.leftButtonClickListener
+                onItemSelectedListener = this@DialogsActivity.onItemSelectedListener
+                closeButtonListener = this@DialogsActivity.infoDialogClosed
+            }
+
 
     private fun getSpannableString(): SpannableStringBuilder =
         SpannableStringBuilder("Lorem ipsum dolor sit amet,")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Start retaining fragment's data and state after configuration change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
Created DialogFragmentArguments class and implement parcelable interface. Create an instance of that class and use it in builder functions by calling setArguments method of DialogFragment. I also created a helper method to retrieve DialogFragment's recently created instance after configuration change and use it to set click listeners in onRestoreInstanceState of Sample Project.
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
After this fix, dialog fragments and their data will survive configuration changes.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Android emulator.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
