### PR TITLE
Quantity picker view/paddings

### DIFF
--- a/buildSrc/src/main/kotlin/ComponentVersions.kt
+++ b/buildSrc/src/main/kotlin/ComponentVersions.kt
@@ -7,7 +7,7 @@ object ComponentVersions {
     const val phoneNumberVersion = "1.0.2"
     const val dialogsVersion = "1.0.7"
     const val cardInputViewVersion = "1.0.5"
-    const val quantityPickerViewVersion = "1.2.0"
+    const val quantityPickerViewVersion = "1.2.1"
     const val timelineViewVersion = "0.1.0"
     const val touchDelegatorVersion = "1.0.0"
 

--- a/buildSrc/src/main/kotlin/ComponentVersions.kt
+++ b/buildSrc/src/main/kotlin/ComponentVersions.kt
@@ -7,7 +7,7 @@ object ComponentVersions {
     const val phoneNumberVersion = "1.0.2"
     const val dialogsVersion = "1.0.7"
     const val cardInputViewVersion = "1.0.5"
-    const val quantityPickerViewVersion = "1.1.1"
+    const val quantityPickerViewVersion = "1.2.0"
     const val timelineViewVersion = "0.1.0"
     const val touchDelegatorVersion = "1.0.0"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,21 +1,10 @@
-# Project-wide Gradle settings.
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app's APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
+org.gradle.jvmargs=-Dfile.encoding=UTF-8
+org.gradle.caching=true
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
-# Kotlin code style for this project: "official" or "obsolete":
-kotlin.code.style=official
+org.gradle.daemon=true
+android.databinding.incremental=true
+kapt.use.worker.api=true
+kapt.include.compile.classpath=false
+kapt.incremental.apt=false
+org.gradle.configureondemand=true

--- a/libraries/quantity-picker-view/README.md
+++ b/libraries/quantity-picker-view/README.md
@@ -1,6 +1,6 @@
 <img src="../../images/quantity-picker-view-1.gif" />
 
-$quantityPickerViewVersion = quantity-picker-view-1.2.0 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+$quantityPickerViewVersion = quantity-picker-view-1.2.1 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## QuantityPickerView
 QuantityPickerView is component for add/remove

--- a/libraries/quantity-picker-view/README.md
+++ b/libraries/quantity-picker-view/README.md
@@ -1,7 +1,6 @@
-
 <img src="../../images/quantity-picker-view-1.gif" />
 
-$quantityPickerViewVersion = quantity-picker-view-1.0.2 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+$quantityPickerViewVersion = quantity-picker-view-1.2.0 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## QuantityPickerView
 QuantityPickerView is component for add/remove
@@ -45,7 +44,11 @@ To set programmatically, you can call `QuantityPickerView.setQuantityPickerViewS
 | qpv_subtractIcon | subtractIconDrawable | Icon for subtract, will be visible when currentQuantity is 2 or more. | [qpv_ic_default_subtract.xml](src/main/res/drawable/qpv_ic_default_subtract.xml) |
 | qpv_quantityBackground | quantityBackgroundDrawable | Background for quantity text. | `transparent` |
 | qpv_orientation | orientation | Determines view orientation. | 'horizontal` |
-| qpv_collapsible | collapsible | Determines if view is collapsible. | 'false'
+| qpv_collapsible | collapsible | Determines if view is collapsible. | 'false' |
+| qpv_buttonVerticalPadding | buttonVerticalPadding | padding for buttons vertically. | `8dp` |
+| qpv_buttonHorizontalPadding | buttonHorizontalPadding | padding for buttons horizontally. | `8dp` |
+| qpv_progressVerticalPadding | progressVerticalPadding | padding for progress bar vertically if `orientation` is `horizontal`, else horizontal padding. | `2dp` |
+| qpv_quantityBackgroundVerticalPadding | quantityBackgroundVerticalPadding | padding for quantity background vertically if `orientation` is `horizontal`, else horizontal padding. | `2dp` |
 
 # Public methods
 

--- a/libraries/quantity-picker-view/src/main/java/com/trendyol/uicomponents/quantitypickerview/BindingAdapters.kt
+++ b/libraries/quantity-picker-view/src/main/java/com/trendyol/uicomponents/quantitypickerview/BindingAdapters.kt
@@ -7,6 +7,7 @@ import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.util.TypedValue
+import android.view.View
 import android.widget.ProgressBar
 import androidx.annotation.ColorInt
 import androidx.appcompat.widget.AppCompatImageView
@@ -49,4 +50,14 @@ internal fun setBackgroundDrawable(imageView: AppCompatImageView, drawable: Draw
 @BindingAdapter("qpv_src")
 internal fun setDrawableSrc(imageView: AppCompatImageView, drawable: Drawable?) {
     imageView.setImageDrawable(drawable)
+}
+
+@BindingAdapter("qpv_horizontalPadding")
+internal fun setHorizontalPadding(view: View, paddingValue: Int) {
+    view.setPadding(paddingValue, view.paddingTop, paddingValue, view.paddingBottom)
+}
+
+@BindingAdapter("qpv_verticalPadding")
+internal fun setVerticalPadding(view: View, paddingValue: Int) {
+    view.setPadding(view.paddingLeft, paddingValue, view.paddingRight, paddingValue)
 }

--- a/libraries/quantity-picker-view/src/main/java/com/trendyol/uicomponents/quantitypickerview/Extensions.kt
+++ b/libraries/quantity-picker-view/src/main/java/com/trendyol/uicomponents/quantitypickerview/Extensions.kt
@@ -7,6 +7,9 @@ import androidx.annotation.AttrRes
 internal fun Context.asSP(value: Int): Int =
     (value * resources.displayMetrics.scaledDensity).toInt()
 
+internal fun Context.asDP(value: Int): Int =
+    (value * resources.displayMetrics.density).toInt()
+
 internal fun Context.themeColor(@AttrRes attrRes: Int): Int {
     val typedValue = TypedValue()
     theme.resolveAttribute(attrRes, typedValue, true)

--- a/libraries/quantity-picker-view/src/main/java/com/trendyol/uicomponents/quantitypickerview/QuantityPickerView.kt
+++ b/libraries/quantity-picker-view/src/main/java/com/trendyol/uicomponents/quantitypickerview/QuantityPickerView.kt
@@ -13,7 +13,6 @@ import androidx.databinding.DataBindingUtil
 import com.trendyol.uicomponents.quantitypickerview.databinding.ViewQuantityPickerBinding
 import com.trendyol.uicomponents.quantitypickerview.databinding.ViewQuantityPickerVerticalBinding
 
-
 class QuantityPickerView : ConstraintLayout {
 
     var onAddClicked: ((Int) -> Boolean)? = null
@@ -23,11 +22,11 @@ class QuantityPickerView : ConstraintLayout {
     private lateinit var binding: ViewQuantityPickerBinding
 
     constructor(context: Context) : super(context) {
-        initializeView(context, null, 0)
+        initializeView()
     }
 
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
-        initializeView(context, attrs, 0)
+        initializeView(attrs)
     }
 
     constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(
@@ -35,10 +34,10 @@ class QuantityPickerView : ConstraintLayout {
         attrs,
         defStyleAttr
     ) {
-        initializeView(context, attrs, defStyleAttr)
+        initializeView(attrs, defStyleAttr)
     }
 
-    private fun initializeView(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int) {
+    private fun initializeView(attrs: AttributeSet? = null, defStyleAttr: Int = 0) {
         val viewState = readAttributes(attrs, defStyleAttr)
         if (isInEditMode) {
             inflateViewForPreview(viewState)
@@ -137,7 +136,7 @@ class QuantityPickerView : ConstraintLayout {
 
     private fun bindRootViewProperties(quantityPickerViewState: QuantityPickerViewState) {
         setBackground(quantityPickerViewState.backgroundDrawable)
-        applyHorizontalPaddingToRootViewIfNeeded(quantityPickerViewState)
+        //applyHorizontalPaddingToRootViewIfNeeded(quantityPickerViewState)
     }
 
     private fun applyHorizontalPaddingToRootViewIfNeeded(viewState: QuantityPickerViewState) {
@@ -262,6 +261,23 @@ class QuantityPickerView : ConstraintLayout {
             val orientation =
                 it.getInt(R.styleable.QuantityPickerView_qpv_orientation, HORIZONTAL_ORIENTATION)
 
+            val buttonHorizontalPadding = it.getDimensionPixelSize(
+                R.styleable.QuantityPickerView_qpv_buttonHorizontalPadding,
+                context.asDP(8)
+            )
+            val buttonVerticalPadding = it.getDimensionPixelSize(
+                R.styleable.QuantityPickerView_qpv_buttonVerticalPadding,
+                context.asDP(8)
+            )
+            val progressVerticalPadding = it.getDimensionPixelSize(
+                R.styleable.QuantityPickerView_qpv_progressVerticalPadding,
+                context.asDP(2)
+            )
+            val quantityBackgroundVerticalPadding = it.getDimensionPixelSize(
+                R.styleable.QuantityPickerView_qpv_quantityBackgroundVerticalPadding,
+                context.asDP(2)
+            )
+
             return QuantityPickerViewState(
                 text = text,
                 textColor = textColor,
@@ -279,10 +295,15 @@ class QuantityPickerView : ConstraintLayout {
                 showLoading = false,
                 quantityBackgroundDrawable = quantityBackground,
                 expansionState = expansionState,
-                orientation = orientation
+                orientation = orientation,
+                buttonHorizontalPadding = buttonHorizontalPadding,
+                buttonVerticalPadding = buttonVerticalPadding,
+                progressVerticalPadding = progressVerticalPadding,
+                quantityBackgroundVerticalPadding = quantityBackgroundVerticalPadding
             )
         }
     }
+
     // endregion readAttrs
     companion object {
         const val HORIZONTAL_ORIENTATION = 0

--- a/libraries/quantity-picker-view/src/main/java/com/trendyol/uicomponents/quantitypickerview/QuantityPickerViewState.kt
+++ b/libraries/quantity-picker-view/src/main/java/com/trendyol/uicomponents/quantitypickerview/QuantityPickerViewState.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import android.view.View
 import androidx.annotation.ColorInt
+import androidx.annotation.DimenRes
 
 data class QuantityPickerViewState(
     private val text: String,
@@ -22,12 +23,14 @@ data class QuantityPickerViewState(
     private val showLoading: Boolean = false,
     private val quantityBackgroundDrawable: Drawable,
     val expansionState: ExpansionState = ExpansionState.NonCollapsible,
-    val orientation: Int = QuantityPickerView.HORIZONTAL_ORIENTATION
+    val orientation: Int = QuantityPickerView.HORIZONTAL_ORIENTATION,
+    val buttonHorizontalPadding: Int,
+    val buttonVerticalPadding: Int,
+    val progressVerticalPadding: Int,
+    val quantityBackgroundVerticalPadding: Int
 ) {
 
     internal fun isInQuantityMode(): Boolean = currentQuantity > 0
-
-    private fun isSingleQuantity(): Boolean = currentQuantity == 1
 
     internal fun isLoading(): Boolean = showLoading
 

--- a/libraries/quantity-picker-view/src/main/res/layout/view_quantity_picker.xml
+++ b/libraries/quantity-picker-view/src/main/res/layout/view_quantity_picker.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:bind="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -12,66 +13,69 @@
 
     <merge
         android:layout_width="wrap_content"
-        android:layout_height="36dp"
+        android:layout_height="wrap_content"
         tools:background="@drawable/qpv_shape_default_background"
-        tools:paddingHorizontal="4dp"
         tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/image_subtract"
-            qpv_src="@{viewState.leftIconDrawable}"
             android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:padding="@dimen/qpv_default_padding"
+            android:layout_height="wrap_content"
             android:visibility="@{viewState.subtractButtonVisibility}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@+id/barrier_end"
+            app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintHorizontal_bias="0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            bind:qpv_horizontalPadding="@{viewState.buttonHorizontalPadding}"
+            bind:qpv_src="@{viewState.leftIconDrawable}"
+            bind:qpv_verticalPadding="@{viewState.buttonVerticalPadding}"
+            tools:paddingHorizontal="8dp"
+            tools:paddingVertical="8dp"
             tools:src="@drawable/qpv_ic_default_remove"
             tools:visibility="visible" />
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/imageQuantityBackground"
-            qpv_src="@{viewState.quantityBackgroundDrawable}"
             android:layout_width="wrap_content"
             android:layout_height="0dp"
             android:adjustViewBounds="true"
-            android:paddingBottom="2dp"
-            android:paddingTop="2dp"
             android:visibility="@{viewState.quantityBackgroundVisibility}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/image_add"
             app:layout_constraintStart_toEndOf="@id/image_subtract"
             app:layout_constraintTop_toTopOf="parent"
+            bind:qpv_src="@{viewState.quantityBackgroundDrawable}"
+            bind:qpv_verticalPadding="@{viewState.quantityBackgroundVerticalPadding}"
+            tools:paddingVertical="2dp"
             tools:src="@drawable/qpv_shape_default_background"
             tools:visibility="visible" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/text"
-            qpv_textAppearance="@{viewState.quantityTextAppearance}"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:fontFamily="sans-serif-medium"
             android:gravity="center"
             android:includeFontPadding="false"
-            android:minEms="3"
-            android:singleLine="true"
+            android:maxLines="1"
+            android:minEms="2"
+            app:layout_constraintDimensionRatio="w, 1:1"
             android:text="@{viewState.quantity}"
             android:visibility="@{viewState.quantityVisibility}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/image_add"
             app:layout_constraintStart_toEndOf="@id/image_subtract"
             app:layout_constraintTop_toTopOf="parent"
+            bind:qpv_textAppearance="@{viewState.quantityTextAppearance}"
             tools:text="1"
             tools:visibility="visible" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/quantityText"
-            qpv_textAppearance="@{viewState.quantityPickerTextAppearance}"
             android:layout_width="wrap_content"
-            android:layout_height="0dp"
+            android:layout_height="wrap_content"
             android:fontFamily="sans-serif-medium"
             android:gravity="center"
             android:includeFontPadding="false"
@@ -83,27 +87,29 @@
             app:layout_constraintEnd_toStartOf="@id/image_add"
             app:layout_constraintStart_toEndOf="@id/image_subtract"
             app:layout_constraintTop_toTopOf="parent"
+            bind:qpv_textAppearance="@{viewState.quantityPickerTextAppearance}"
             tools:text="Add to Cart"
             tools:visibility="gone" />
 
         <ProgressBar
             android:id="@+id/progress_bar"
-            qpv_progressTint="@{viewState.progressTintColor}"
-            android:layout_width="wrap_content"
-            android:layout_height="32dp"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:visibility="@{viewState.progressBarVisibility}"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="h 1:1"
             app:layout_constraintEnd_toStartOf="@id/image_add"
             app:layout_constraintStart_toEndOf="@id/image_subtract"
             app:layout_constraintTop_toTopOf="parent"
+            bind:qpv_progressTint="@{viewState.progressTintColor}"
+            bind:qpv_verticalPadding="@{viewState.progressVerticalPadding}"
+            tools:paddingVertical="2dp"
             tools:visibility="gone" />
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/image_add"
-            qpv_src="@{viewState.addIconDrawable}"
             android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:padding="@dimen/qpv_default_padding"
+            android:layout_height="wrap_content"
             android:visibility="@{viewState.addButtonVisibility}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintDimensionRatio="1:1"
@@ -111,6 +117,11 @@
             app:layout_constraintHorizontal_bias="1"
             app:layout_constraintStart_toStartOf="@id/barrier_start"
             app:layout_constraintTop_toTopOf="parent"
+            bind:qpv_horizontalPadding="@{viewState.buttonHorizontalPadding}"
+            bind:qpv_src="@{viewState.addIconDrawable}"
+            bind:qpv_verticalPadding="@{viewState.buttonVerticalPadding}"
+            tools:paddingHorizontal="8dp"
+            tools:paddingVertical="8dp"
             tools:src="@drawable/qpv_ic_default_add"
             tools:visibility="visible" />
 
@@ -119,13 +130,13 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:barrierDirection="start"
-            app:constraint_referenced_ids="text,progress_bar" />
+            app:constraint_referenced_ids="imageQuantityBackground,progress_bar" />
 
         <androidx.constraintlayout.widget.Barrier
             android:id="@+id/barrier_start"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:barrierDirection="end"
-            app:constraint_referenced_ids="text,progress_bar" />
+            app:constraint_referenced_ids="imageQuantityBackground,progress_bar" />
     </merge>
 </layout>

--- a/libraries/quantity-picker-view/src/main/res/layout/view_quantity_picker.xml
+++ b/libraries/quantity-picker-view/src/main/res/layout/view_quantity_picker.xml
@@ -74,8 +74,8 @@
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/quantityText"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:fontFamily="sans-serif-medium"
             android:gravity="center"
             android:includeFontPadding="false"

--- a/libraries/quantity-picker-view/src/main/res/layout/view_quantity_picker_vertical.xml
+++ b/libraries/quantity-picker-view/src/main/res/layout/view_quantity_picker_vertical.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:bind="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -11,84 +12,86 @@
     </data>
 
     <merge
-        android:layout_width="36dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        tools:paddingHorizontal="4dp"
         tools:background="@drawable/qpv_shape_default_background"
         tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@id/image_add"
-            qpv_src="@{viewState.addIconDrawable}"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:padding="@dimen/qpv_default_padding"
             android:visibility="@{viewState.addButtonVisibility}"
-            app:layout_constraintBottom_toTopOf="@id/imageQuantityBackground"
+            app:layout_constraintBottom_toTopOf="@id/barrier_top"
+            app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_chainStyle="spread_inside"
+            bind:qpv_horizontalPadding="@{viewState.buttonHorizontalPadding}"
+            bind:qpv_src="@{viewState.addIconDrawable}"
+            bind:qpv_verticalPadding="@{viewState.buttonVerticalPadding}"
+            tools:paddingHorizontal="8dp"
+            tools:paddingVertical="8dp"
             tools:src="@drawable/qpv_ic_default_add"
             tools:visibility="visible" />
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@id/imageQuantityBackground"
-            qpv_src="@{viewState.quantityBackgroundDrawable}"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:adjustViewBounds="true"
             android:visibility="@{viewState.quantityBackgroundVisibility}"
             app:layout_constraintBottom_toTopOf="@id/image_subtract"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/image_add"
-            android:layout_marginBottom="@dimen/qpv_default_padding"
-            android:layout_marginTop="@dimen/qpv_default_padding"
-            android:layout_marginStart="2dp"
-            android:layout_marginEnd="2dp"
+            bind:qpv_horizontalPadding="@{viewState.quantityBackgroundVerticalPadding}"
+            bind:qpv_src="@{viewState.quantityBackgroundDrawable}"
+            tools:paddingHorizontal="2dp"
             tools:src="@drawable/qpv_shape_default_background"
             tools:visibility="visible" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@id/text"
-            qpv_textAppearance="@{viewState.quantityTextAppearance}"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:fontFamily="sans-serif-medium"
+            app:layout_constraintDimensionRatio="h, 1:1"
             android:gravity="center"
             android:includeFontPadding="false"
-            android:singleLine="true"
+            android:maxLines="1"
+            android:minEms="2"
             android:text="@{viewState.quantity}"
-            tools:text="2"
             android:visibility="@{viewState.quantityVisibility}"
             app:layout_constraintBottom_toTopOf="@id/image_subtract"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/image_add"
+            bind:qpv_textAppearance="@{viewState.quantityTextAppearance}"
+            tools:text="1"
             tools:visibility="visible" />
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@id/image_subtract"
-            qpv_src="@{viewState.leftIconDrawable}"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:padding="@dimen/qpv_default_padding"
             android:visibility="@{viewState.subtractButtonVisibility}"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/imageQuantityBackground"
+            app:layout_constraintTop_toBottomOf="@id/barrier_bottom"
+            bind:qpv_horizontalPadding="@{viewState.buttonHorizontalPadding}"
+            bind:qpv_src="@{viewState.leftIconDrawable}"
+            bind:qpv_verticalPadding="@{viewState.buttonVerticalPadding}"
+            tools:paddingHorizontal="8dp"
+            tools:paddingVertical="8dp"
             tools:src="@drawable/qpv_ic_default_remove"
             tools:visibility="visible" />
 
         <ProgressBar
             android:id="@id/progress_bar"
-            qpv_progressTint="@{viewState.progressTintColor}"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:visibility="@{viewState.progressBarVisibility}"
@@ -96,6 +99,9 @@
             app:layout_constraintEnd_toEndOf="@id/imageQuantityBackground"
             app:layout_constraintStart_toStartOf="@id/imageQuantityBackground"
             app:layout_constraintTop_toTopOf="@id/imageQuantityBackground"
+            bind:qpv_horizontalPadding="@{viewState.progressVerticalPadding}"
+            bind:qpv_progressTint="@{viewState.progressTintColor}"
+            tools:paddingHorizontal="2dp"
             tools:visibility="gone" />
 
         <androidx.appcompat.widget.AppCompatTextView
@@ -103,7 +109,20 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"
-            tools:text="Add to Cart"
-            />
+            tools:text="Add to Cart" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/barrier_bottom"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="imageQuantityBackground,progress_bar" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/barrier_top"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="top"
+            app:constraint_referenced_ids="imageQuantityBackground,progress_bar" />
     </merge>
 </layout>

--- a/libraries/quantity-picker-view/src/main/res/values/attrs.xml
+++ b/libraries/quantity-picker-view/src/main/res/values/attrs.xml
@@ -30,5 +30,9 @@
             <enum name="horizontal" value="0"/>
             <enum name="vertical" value="1" />
         </attr>
+        <attr name="qpv_buttonVerticalPadding" format="dimension"/>
+        <attr name="qpv_buttonHorizontalPadding" format="dimension" />
+        <attr name="qpv_progressVerticalPadding" format="dimension" />
+        <attr name="qpv_quantityBackgroundVerticalPadding" format="dimension" />
     </declare-styleable>
 </resources>

--- a/sample/src/main/java/com/trendyol/uicomponents/Extensions.kt
+++ b/sample/src/main/java/com/trendyol/uicomponents/Extensions.kt
@@ -19,3 +19,6 @@ fun Context.drawable(@DrawableRes resId: Int): Drawable =
 
 fun Context.asSP(value: Int): Int =
     (value * resources.displayMetrics.scaledDensity).toInt()
+
+fun Context.asDP(value: Int): Int =
+    (value * resources.displayMetrics.density).toInt()

--- a/sample/src/main/java/com/trendyol/uicomponents/QuantityPickerViewActivity.kt
+++ b/sample/src/main/java/com/trendyol/uicomponents/QuantityPickerViewActivity.kt
@@ -26,7 +26,11 @@ class QuantityPickerViewActivity : AppCompatActivity() {
             quantityBackgroundDrawable = drawable(R.drawable.qpv_shape_default_background),
             textColor = themeColor(R.attr.colorAccent),
             progressTintColor = themeColor(R.attr.colorAccent),
-            quantityTextColor = themeColor(R.attr.colorPrimary)
+            quantityTextColor = themeColor(R.attr.colorPrimary),
+            buttonHorizontalPadding = asDP(8),
+            buttonVerticalPadding = asDP(8),
+            progressVerticalPadding = asDP(6),
+            quantityBackgroundVerticalPadding = asDP(6)
         )
 
         quantity_picker_view_2.setQuantityPickerViewState(viewState)

--- a/sample/src/main/res/layout/activity_quantity_picker_view.xml
+++ b/sample/src/main/res/layout/activity_quantity_picker_view.xml
@@ -40,8 +40,8 @@
                 android:id="@+id/quantity_picker_view"
                 android:layout_width="match_parent"
                 android:layout_height="40dp"
-                app:qpv_currentQuantity="1"
                 android:animateLayoutChanges="true"
+                app:qpv_currentQuantity="1"
                 app:qpv_quantityBackground="@drawable/qpv_shape_default_background"
                 app:qpv_quantityTextSize="14sp"
                 app:qpv_text="Add to Cart"
@@ -124,12 +124,16 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
+                android:animateLayoutChanges="true"
                 android:clipChildren="false"
                 android:elevation="4dp"
+                app:qpv_buttonHorizontalPadding="8dp"
+                app:qpv_buttonVerticalPadding="8dp"
                 app:qpv_collapsible="true"
                 app:qpv_currentQuantity="1"
-                android:animateLayoutChanges="true"
+                app:qpv_progressVerticalPadding="4dp"
                 app:qpv_quantityBackground="@drawable/qpv_shape_default_background"
+                app:qpv_quantityBackgroundVerticalPadding="4dp"
                 app:qpv_quantityTextSize="14sp"
                 app:qpv_text="Add to Cart"
                 app:qpv_textSize="12sp" />
@@ -146,8 +150,7 @@
         app:contentPadding="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@id/card_view_right"
-        app:layout_constraintTop_toBottomOf="@id/card_view_right"
-        >
+        app:layout_constraintTop_toBottomOf="@id/card_view_right">
 
         <RelativeLayout
             android:layout_width="match_parent"
@@ -173,16 +176,20 @@
 
             <com.trendyol.uicomponents.quantitypickerview.QuantityPickerView
                 android:id="@+id/quantity_picker_view_collapsed_right"
-                android:animateLayoutChanges="true"
-                android:layout_width="36dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
+                android:animateLayoutChanges="true"
                 android:clipChildren="false"
                 android:elevation="4dp"
+                app:qpv_buttonHorizontalPadding="8dp"
+                app:qpv_buttonVerticalPadding="8dp"
                 app:qpv_collapsible="true"
-                app:qpv_orientation="vertical"
                 app:qpv_currentQuantity="1"
+                app:qpv_orientation="vertical"
+                app:qpv_progressVerticalPadding="4dp"
                 app:qpv_quantityBackground="@drawable/qpv_shape_default_background"
+                app:qpv_quantityBackgroundVerticalPadding="4dp"
                 app:qpv_quantityTextSize="14sp"
                 app:qpv_text="Add to Cart"
                 app:qpv_textSize="12sp" />


### PR DESCRIPTION
Update for supporting custom paddings on buttons and ProgressBar and quantityBackground.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
- Update quantity-picker-view-1.gif.
- Update README.md for quantity-picker-view.
- Set quantity-picker-view version to 1.2.0.
- Set quantityText size as match parent to handle click on all view when quantity text is visible.
- Se tquantity-picker-view version to 1.2.1.

## How Has This Been Tested?
Tested on emulator with Android R developer preview installed.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
