### PR TITLE
Feature/add flag for using subtract icon

### DIFF
--- a/buildSrc/src/main/kotlin/ComponentVersions.kt
+++ b/buildSrc/src/main/kotlin/ComponentVersions.kt
@@ -7,7 +7,7 @@ object ComponentVersions {
     const val phoneNumberVersion = "1.0.2"
     const val dialogsVersion = "1.0.17"
     const val cardInputViewVersion = "1.0.5"
-    const val quantityPickerViewVersion = "1.2.2-alpha01"
+    const val quantityPickerViewVersion = "1.2.2"
     const val timelineViewVersion = "1.0.0"
     const val touchDelegatorVersion = "1.0.0"
     const val fitOptionMessageView = "1.0.0"

--- a/buildSrc/src/main/kotlin/ComponentVersions.kt
+++ b/buildSrc/src/main/kotlin/ComponentVersions.kt
@@ -7,7 +7,7 @@ object ComponentVersions {
     const val phoneNumberVersion = "1.0.2"
     const val dialogsVersion = "1.0.17"
     const val cardInputViewVersion = "1.0.5"
-    const val quantityPickerViewVersion = "1.2.1"
+    const val quantityPickerViewVersion = "1.2.2-alpha01"
     const val timelineViewVersion = "1.0.0"
     const val touchDelegatorVersion = "1.0.0"
     const val fitOptionMessageView = "1.0.0"

--- a/libraries/quantity-picker-view/README.md
+++ b/libraries/quantity-picker-view/README.md
@@ -1,6 +1,6 @@
 <img src="../../images/quantity-picker-view-1.gif" />
 
-$quantityPickerViewVersion = quantity-picker-view-1.2.1 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+$quantityPickerViewVersion = quantity-picker-view-1.2.2 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## QuantityPickerView
 QuantityPickerView is component for add/remove
@@ -49,6 +49,8 @@ To set programmatically, you can call `QuantityPickerView.setQuantityPickerViewS
 | qpv_buttonHorizontalPadding | buttonHorizontalPadding | padding for buttons horizontally. | `8dp` |
 | qpv_progressVerticalPadding | progressVerticalPadding | padding for progress bar vertically if `orientation` is `horizontal`, else horizontal padding. | `2dp` |
 | qpv_quantityBackgroundVerticalPadding | quantityBackgroundVerticalPadding | padding for quantity background vertically if `orientation` is `horizontal`, else horizontal padding. | `2dp` |
+| qpv_qpv_alwaysSubtractIcon | alwaysSubtractIcon | flag for using subtract icon event when quantity is 1 | `false` |
+
 
 # Public methods
 

--- a/libraries/quantity-picker-view/src/main/java/com/trendyol/uicomponents/quantitypickerview/QuantityPickerView.kt
+++ b/libraries/quantity-picker-view/src/main/java/com/trendyol/uicomponents/quantitypickerview/QuantityPickerView.kt
@@ -278,6 +278,8 @@ class QuantityPickerView : ConstraintLayout {
                 context.asDP(2)
             )
 
+            val alwaysSubtractIcon = it.getBoolean(R.styleable.QuantityPickerView_qpv_alwaysSubtractIcon, false)
+
             return QuantityPickerViewState(
                 text = text,
                 textColor = textColor,
@@ -299,7 +301,8 @@ class QuantityPickerView : ConstraintLayout {
                 buttonHorizontalPadding = buttonHorizontalPadding,
                 buttonVerticalPadding = buttonVerticalPadding,
                 progressVerticalPadding = progressVerticalPadding,
-                quantityBackgroundVerticalPadding = quantityBackgroundVerticalPadding
+                quantityBackgroundVerticalPadding = quantityBackgroundVerticalPadding,
+                alwaysSubtractIcon = alwaysSubtractIcon
             )
         }
     }

--- a/libraries/quantity-picker-view/src/main/java/com/trendyol/uicomponents/quantitypickerview/QuantityPickerViewState.kt
+++ b/libraries/quantity-picker-view/src/main/java/com/trendyol/uicomponents/quantitypickerview/QuantityPickerViewState.kt
@@ -27,7 +27,8 @@ data class QuantityPickerViewState(
     val buttonHorizontalPadding: Int,
     val buttonVerticalPadding: Int,
     val progressVerticalPadding: Int,
-    val quantityBackgroundVerticalPadding: Int
+    val quantityBackgroundVerticalPadding: Int,
+    val alwaysSubtractIcon: Boolean = false
 ) {
 
     internal fun isInQuantityMode(): Boolean = currentQuantity > 0
@@ -35,7 +36,7 @@ data class QuantityPickerViewState(
     internal fun isLoading(): Boolean = showLoading
 
     fun getLeftIconDrawable(): Drawable =
-        if (currentQuantity <= 1) removeIconDrawable else subtractIconDrawable
+        if (currentQuantity <= 1 && alwaysSubtractIcon.not()) removeIconDrawable else subtractIconDrawable
 
     fun getAddButtonVisibility(): Int =
         if (isInQuantityMode() || expansionState is ExpansionState.Collapsible || showLoading) View.VISIBLE else View.GONE

--- a/libraries/quantity-picker-view/src/main/res/values/attrs.xml
+++ b/libraries/quantity-picker-view/src/main/res/values/attrs.xml
@@ -34,5 +34,6 @@
         <attr name="qpv_buttonHorizontalPadding" format="dimension" />
         <attr name="qpv_progressVerticalPadding" format="dimension" />
         <attr name="qpv_quantityBackgroundVerticalPadding" format="dimension" />
+        <attr name="qpv_alwaysSubtractIcon" format="boolean" />
     </declare-styleable>
 </resources>

--- a/sample/src/main/res/layout/activity_quantity_picker_view.xml
+++ b/sample/src/main/res/layout/activity_quantity_picker_view.xml
@@ -45,6 +45,7 @@
                 app:qpv_quantityBackground="@drawable/qpv_shape_default_background"
                 app:qpv_quantityTextSize="14sp"
                 app:qpv_text="Add to Cart"
+                app:qpv_alwaysSubtractIcon="true"
                 app:qpv_textSize="12sp" />
         </LinearLayout>
     </androidx.cardview.widget.CardView>


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Added boolean flag with default parameter.

## Motivation and Context
This gives you the ability to use subtract icon resource even when quantity is one.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
