### PR TITLE
Fix fragment_dialog focus bug on edit text

### DIFF
--- a/buildSrc/src/main/kotlin/ComponentVersions.kt
+++ b/buildSrc/src/main/kotlin/ComponentVersions.kt
@@ -5,7 +5,7 @@ object ComponentVersions {
     const val ratingBarVersion = "1.0.2"
     const val imageSliderVersion = "1.0.5"
     const val phoneNumberVersion = "1.0.2"
-    const val dialogsVersion = "1.1.0"
+    const val dialogsVersion = "1.1.1"
     const val cardInputViewVersion = "1.1.2"
     const val quantityPickerViewVersion = "1.2.1"
     const val timelineViewVersion = "1.0.0"

--- a/libraries/dialogs/src/main/res/layout/fragment_dialog.xml
+++ b/libraries/dialogs/src/main/res/layout/fragment_dialog.xml
@@ -19,6 +19,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:focusableInTouchMode="true"
             android:orientation="vertical">
 
             <LinearLayout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Added focusableInTouchMode for parent of search edit text in dialog fragment

## Motivation and Context
Fixes a bug.

## How Has This Been Tested?
Tested myself.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
