### PR TITLE
image-slider float range check fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven("https://jitpack.io")
     }
 }
 

--- a/buildSrc/src/main/kotlin/ComponentVersions.kt
+++ b/buildSrc/src/main/kotlin/ComponentVersions.kt
@@ -3,7 +3,7 @@ object ComponentVersions {
     const val toolbarVersion = "1.2.3"
     const val suggestionInputViewVersion = "1.0.12"
     const val ratingBarVersion = "1.0.2"
-    const val imageSliderVersion = "1.0.7"
+    const val imageSliderVersion = "1.0.8"
     const val phoneNumberVersion = "1.0.2"
     const val dialogsVersion = "1.1.3"
     const val cardInputViewVersion = "1.1.2"

--- a/buildSrc/src/main/kotlin/ComponentVersions.kt
+++ b/buildSrc/src/main/kotlin/ComponentVersions.kt
@@ -3,7 +3,7 @@ object ComponentVersions {
     const val toolbarVersion = "1.2.3"
     const val suggestionInputViewVersion = "1.0.12"
     const val ratingBarVersion = "1.0.2"
-    const val imageSliderVersion = "1.0.5"
+    const val imageSliderVersion = "1.0.7"
     const val phoneNumberVersion = "1.0.2"
     const val dialogsVersion = "1.1.3"
     const val cardInputViewVersion = "1.1.2"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,7 +7,7 @@ object Dependencies {
     const val material = "com.google.android.material:material:1.1.0"
     const val constraintLayout = "androidx.constraintlayout:constraintlayout:1.1.3"
     const val recyclerView = "androidx.recyclerview:recyclerview:1.1.0"
-    const val circleIndicator = "me.relex:circleindicator:2.1.4"
+    const val circleIndicator = "com.github.MertNYuksel:CircleIndicator::2a2e973374"
     const val glide = "com.github.bumptech.glide:glide:4.10.0"
     const val glideCompiler = "com.github.bumptech.glide:compiler:4.10.0"
     const val lifecycleExtensions = "androidx.lifecycle:lifecycle-extensions:2.1.0"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,7 +7,7 @@ object Dependencies {
     const val material = "com.google.android.material:material:1.1.0"
     const val constraintLayout = "androidx.constraintlayout:constraintlayout:1.1.3"
     const val recyclerView = "androidx.recyclerview:recyclerview:1.1.0"
-    const val circleIndicator = "com.github.MertNYuksel:CircleIndicator::2a2e973374"
+    const val circleIndicator = "com.github.MertNYuksel:CircleIndicator:2a2e973374"
     const val glide = "com.github.bumptech.glide:glide:4.10.0"
     const val glideCompiler = "com.github.bumptech.glide:compiler:4.10.0"
     const val lifecycleExtensions = "androidx.lifecycle:lifecycle-extensions:2.1.0"

--- a/libraries/image-slider/src/main/java/com/trendyol/uicomponents/imageslider/Extensions.kt
+++ b/libraries/image-slider/src/main/java/com/trendyol/uicomponents/imageslider/Extensions.kt
@@ -53,9 +53,7 @@ internal fun MotionEvent.calculateAverageTouch(): Point {
 }
 
 internal fun calculateDistance(x: Float, y: Float, x1: Float, y1: Float): Float {
-    return sqrt(
-        (x - x1).toDouble().pow(2.0) + (y - y1).toDouble().pow(2.0)
-    ).toFloat()
+    return sqrt((x - x1).toDouble().pow(2.0) + (y - y1).toDouble().pow(2.0)).toFloat()
 }
 
 internal fun View.getScaledHeight(): Int {
@@ -72,8 +70,10 @@ internal fun View.setPivot(point: Point) {
 }
 
 internal fun View.setScale(scaleFactor: Float) {
-    scaleY = scaleFactor
-    scaleX = scaleFactor
+    if (scaleFactor in Float.MIN_VALUE..Float.MAX_VALUE) {
+        scaleY = scaleFactor
+        scaleX = scaleFactor
+    }
 }
 
 internal fun View.getViewPosition(): Point {


### PR DESCRIPTION
Add range check to setScale method on image-slider library to prevent possible IllegalArgumentException.
Update image-slider version to 1.0.8.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
This check prevents possible IllegalArgumentException at [View.java:17455](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/java/android/view/View.java#17455).

## Motivation and Context

## How Has This Been Tested?
Tested on physical device with Android 10.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
