### PR TITLE
Implement controll on keyboard for type input

### DIFF
--- a/buildSrc/src/main/kotlin/ComponentVersions.kt
+++ b/buildSrc/src/main/kotlin/ComponentVersions.kt
@@ -1,7 +1,7 @@
 object ComponentVersions {
 
     const val toolbarVersion = "2.0.4"
-    const val suggestionInputViewVersion = "1.0.12"
+    const val suggestionInputViewVersion = "1.0.13"
     const val ratingBarVersion = "1.0.2"
     const val imageSliderVersion = "1.0.8"
     const val phoneNumberVersion = "1.0.2"

--- a/libraries/suggestion-input-view/README.md
+++ b/libraries/suggestion-input-view/README.md
@@ -42,7 +42,8 @@ To set width you can use `android:layout_width` attribute. To customize more you
 | `app:inputSuffix` | `setInputSuffix(String)` | Suffix of input view's edit text | Empty String | app:inputSuffix="₺"|
 | `android:inputType` | `` | Input type of input view's edit text input type | TYPE_TEXT_VARIATION_NORMAL | android:inputType="number"|
 | `app:shouldShowSelectableItemError` | `shouldShowSelectableItemError(Boolean)` | Change suggestion item's background | false | app:shouldShowError="@{true}"|
-| `app:inputHint` |  | Hint of input view's edit text | Empty String | app:inputHint="Hint of input edit text"|
+| `app:inputHint` | `setInputHint(String)` | Hint of input view's edit text | Empty String | app:inputHint="Hint of input edit text"|
+| `app:showKeyboardByDefault` |  | show keyboard or not by default for input view | true | app:showKeyboardByDefault="false"|
 
 # Contributors
 This library is maintained mainly by Trendyol Android Team members but also other Android lovers contributes.

--- a/libraries/suggestion-input-view/src/main/res/values/attrs.xml
+++ b/libraries/suggestion-input-view/src/main/res/values/attrs.xml
@@ -26,11 +26,13 @@
         <attr name="inputEditTextBackground" format="reference" />
         <!-- input views's edit text suffix -->
         <attr name="inputSuffix" format="string" />
+        <!-- input views's edit text hint-->
+        <attr name="inputHint" format="string"/>
         <!-- input type for input view's edit text -->
         <attr name="android:inputType" />
+        <!-- show keyboard or not by default for input view -->
+        <attr name="showKeyboardByDefault" format="boolean"/>
         <!-- error background -->
         <attr name="errorBackground" format="reference" />
-        <!-- hint of input edittext -->
-        <attr name="inputHint" format="string"/>
     </declare-styleable>
 </resources>

--- a/sample/src/main/java/com/trendyol/uicomponents/SuggestionInputViewActivity.kt
+++ b/sample/src/main/java/com/trendyol/uicomponents/SuggestionInputViewActivity.kt
@@ -1,7 +1,7 @@
 package com.trendyol.uicomponents
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.trendyol.suggestioninputview.Rule
 import com.trendyol.suggestioninputview.SuggestionInputItem
@@ -27,7 +27,7 @@ class SuggestionInputViewActivity : AppCompatActivity() {
             .notEqualsTo("0")
             .errorMessage("0 giremezsin")
             .build()
-        binding.suggestionInputView.setRuleSet(listOf(rule1,rule2))
+        binding.suggestionInputView.setRuleSet(listOf(rule1, rule2))
         binding.suggestionInputView.setSuggestionItemClickListener { onSuggestionItemClicked(it) }
         binding.suggestionInputView.setItems(createSuggestionInputItems())
         binding.buttonLoad.setOnClickListener { onLoadClicked() }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Added **showKeyboardByDefault** attribute
 
showKeyboardByDefault attribute controls the keyboard state in a way that is showing or not when the suggestion item INPUT is selected by default

## Motivation and Context
While the view is initiated with items that have an item whose type is INPUT and state is selected, the keyboard is opening by default. This newly added attribute gave the ability to the view to control the keyboard state.

## How Has This Been Tested?
Tested on :
- emulator with Android version 8.1
- Xiaomi mi 6 with Android version 9.0

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
