### PR TITLE
Add Optional Padding For Dialog

### DIFF
--- a/buildSrc/src/main/kotlin/ComponentVersions.kt
+++ b/buildSrc/src/main/kotlin/ComponentVersions.kt
@@ -5,7 +5,7 @@ object ComponentVersions {
     const val ratingBarVersion = "1.0.2"
     const val imageSliderVersion = "1.0.8"
     const val phoneNumberVersion = "1.0.2"
-    const val dialogsVersion = "1.2.9"
+    const val dialogsVersion = "1.3.0"
     const val cardInputViewVersion = "1.1.3"
     const val quantityPickerViewVersion = "1.2.5"
     const val timelineViewVersion = "1.0.0"

--- a/libraries/dialogs/README.md
+++ b/libraries/dialogs/README.md
@@ -37,6 +37,8 @@ Simple dialog to show information, error or text.
 | `showCloseButton` | Boolean | Close button visibility | false |
 | `animateCornerRadiusWhenExpand` | Boolean | Corner radius will be removed with an animation when set true. | false |  
 | `cornerRadius` | Float | Corner radius will be applied. | 16dp |
+| `horizontalPadding` | Float | Horizontal padding will be applied. | 16dp |
+| `verticalPadding` | Float | Vertical padding will be applied. | 0dp |
 | `closeButtonListener` | (DialogFragment) -> Unit | Listener for close button. When clicked, dialog will dismiss and listener will be invoked with dialog. | { } |
 | `content` | CharSequence | Content of a dialog | "" |
 | `showContentAsHtml` | Boolean | If you provided `content` as Html and set this flag as true, content will be parsed as HTML. | false |
@@ -174,6 +176,8 @@ CustomDialog is a dialog that has a fixed header and its content can take a cust
 | Field | Type | Description | Default Value |
 | ------------- |-------------|-------------| ------------- |
 | `view` | View | The custom view that will create the body of the dialog. | null |
+| `horizontalPadding` | Float | Horizontal padding will be applied. | 0dp |
+| `verticalPadding` | Float | Vertical padding will be applied. | 0dp |
 
 Sample usage:
 ```kotlin

--- a/libraries/dialogs/README.md
+++ b/libraries/dialogs/README.md
@@ -1,7 +1,7 @@
 
 <img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-1.png" width="280"/> <img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-2.png" width="280"/> <img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-3.png" width="280"/> <img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-4.png" width="280"/> <img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-5.png" width="280"/> <img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-6.png" width="280"/>
   
-$dialogsVersion = dialogs-1.2.9 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+$dialogsVersion = dialogs-1.3.0 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
   
 ## Dialogs  
 Dialogs is a bunch of BottomSheetDialogs to use in app to show user an information, agreement or list.  

--- a/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/Builder.kt
+++ b/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/Builder.kt
@@ -15,6 +15,8 @@ open class Builder internal constructor() {
     var closeButtonListener: ((DialogFragment) -> Unit)? = null
     var animateCornerRadiusWhenExpand: Boolean = false
     var cornerRadius: Float? = null
+    var horizontalPadding: Float? = null
+    var verticalPadding: Float? = null
 }
 
 open class InfoDialogBuilder internal constructor() : Builder() {
@@ -36,6 +38,8 @@ open class InfoDialogBuilder internal constructor() : Builder() {
                     showCloseButton = it.showCloseButton,
                     animateCornerRadiusWhenExpand = it.animateCornerRadiusWhenExpand,
                     cornerRadius = it.cornerRadius,
+                    horizontalPadding = it.horizontalPadding,
+                    verticalPadding = it.verticalPadding,
                     content = SpannableString(it.content),
                     contentImage = it.contentImage,
                     showContentAsHtml = it.showContentAsHtml,
@@ -67,6 +71,8 @@ open class AgreementDialogBuilder internal constructor() : InfoDialogBuilder() {
                     showCloseButton = it.showCloseButton,
                     content = SpannableString(it.content),
                     cornerRadius = it.cornerRadius,
+                    horizontalPadding = it.horizontalPadding,
+                    verticalPadding = it.verticalPadding,
                     showContentAsHtml = it.showContentAsHtml,
                     contentImage = it.contentImage,
                     rightButtonText = it.rightButtonText,
@@ -103,6 +109,8 @@ class SelectionDialogBuilder internal constructor() : InfoDialogBuilder() {
                     showContentAsHtml = it.showContentAsHtml,
                     contentImage = it.contentImage,
                     cornerRadius = it.cornerRadius,
+                    horizontalPadding = it.horizontalPadding,
+                    verticalPadding = it.verticalPadding,
                     animateCornerRadiusWhenExpand = it.animateCornerRadiusWhenExpand,
                     titleTextColor = it.titleTextColor,
                     items = it.items,
@@ -137,6 +145,8 @@ class InfoListDialogBuilder internal constructor() : InfoDialogBuilder() {
                     content = SpannableString(it.content),
                     animateCornerRadiusWhenExpand = it.animateCornerRadiusWhenExpand,
                     cornerRadius = it.cornerRadius,
+                    horizontalPadding = it.horizontalPadding,
+                    verticalPadding = it.verticalPadding,
                     showContentAsHtml = it.showContentAsHtml,
                     contentImage = it.contentImage,
                     webViewContent = it.webViewContent,
@@ -161,6 +171,8 @@ class CustomDialogBuilder internal constructor() : Builder() {
                     showCloseButton = it.showCloseButton,
                     animateCornerRadiusWhenExpand = animateCornerRadiusWhenExpand,
                     cornerRadius = it.cornerRadius,
+                    horizontalPadding = it.horizontalPadding ?: 0.0F,
+                    verticalPadding = it.verticalPadding,
                     titleBackgroundColor = it.titleBackgroundColor,
                     titleTextColor = it.titleTextColor,
                     titleTextPosition = it.titleTextPosition,

--- a/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/Builder.kt
+++ b/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/Builder.kt
@@ -15,8 +15,6 @@ open class Builder internal constructor() {
     var closeButtonListener: ((DialogFragment) -> Unit)? = null
     var animateCornerRadiusWhenExpand: Boolean = false
     var cornerRadius: Float? = null
-    var horizontalPadding: Float? = null
-    var verticalPadding: Float? = null
 }
 
 open class InfoDialogBuilder internal constructor() : Builder() {
@@ -29,6 +27,8 @@ open class InfoDialogBuilder internal constructor() : Builder() {
     var contentTextPosition: TextPosition? = null
     var webViewContent: WebViewContent? = null
     var webViewBuilder: (WebView.() -> Unit)? = null
+    var horizontalPadding: Float? = null
+    var verticalPadding: Float? = null
 
     internal fun buildInfoDialog(block: InfoDialogBuilder.() -> Unit): DialogFragment {
         return InfoDialogBuilder().apply(block).let {
@@ -171,8 +171,8 @@ class CustomDialogBuilder internal constructor() : Builder() {
                     showCloseButton = it.showCloseButton,
                     animateCornerRadiusWhenExpand = animateCornerRadiusWhenExpand,
                     cornerRadius = it.cornerRadius,
-                    horizontalPadding = it.horizontalPadding ?: 0.0F,
-                    verticalPadding = it.verticalPadding,
+                    horizontalPadding = 0.0F,
+                    verticalPadding = 0.0F,
                     titleBackgroundColor = it.titleBackgroundColor,
                     titleTextColor = it.titleTextColor,
                     titleTextPosition = it.titleTextPosition,

--- a/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragment.kt
+++ b/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragment.kt
@@ -84,11 +84,13 @@ class DialogFragment internal constructor() : BaseBottomSheetDialog() {
             dialogArguments.infoListItems?.let { items ->
                 initializeInfoListDialog(items, dialogArguments.itemDividers)
             }
-
-            val horizontalPadding = dialogArguments.horizontalPadding?.toInt()
-                ?: requireContext().pixel(R.dimen.ui_components_dialogs_margin_outer).toInt()
-            val verticalPadding = dialogArguments.verticalPadding?.toInt() ?: 0
-            nestedScrollView.setPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding)
+            if (dialogArguments.horizontalPadding != null || dialogArguments.verticalPadding != null) {
+                val topPadding = dialogArguments.verticalPadding?.toInt() ?: nestedScrollView.paddingTop
+                val bottomPadding = dialogArguments.verticalPadding?.toInt() ?: nestedScrollView.paddingBottom
+                val startPadding = dialogArguments.horizontalPadding?.toInt() ?: nestedScrollView.paddingStart
+                val endPadding = dialogArguments.horizontalPadding?.toInt() ?: nestedScrollView.paddingEnd
+                nestedScrollView.setPadding(startPadding, topPadding, endPadding, bottomPadding)
+            }
         }
     }
 

--- a/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragment.kt
+++ b/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragment.kt
@@ -84,6 +84,11 @@ class DialogFragment internal constructor() : BaseBottomSheetDialog() {
             dialogArguments.infoListItems?.let { items ->
                 initializeInfoListDialog(items, dialogArguments.itemDividers)
             }
+
+            val horizontalPadding = dialogArguments.horizontalPadding?.toInt()
+                ?: requireContext().pixel(R.dimen.ui_components_dialogs_margin_outer).toInt()
+            val verticalPadding = dialogArguments.verticalPadding?.toInt() ?: 0
+            nestedScrollView.setPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding)
         }
     }
 

--- a/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragmentArguments.kt
+++ b/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragmentArguments.kt
@@ -15,6 +15,8 @@ class DialogFragmentArguments(
     val showCloseButton: Boolean? = null,
     val animateCornerRadiusWhenExpand: Boolean = true,
     val cornerRadius: Float? = null,
+    val horizontalPadding: Float? = null,
+    val verticalPadding: Float? = null,
     val content: CharSequence? = null,
     val showContentAsHtml: Boolean = false,
     @DrawableRes val contentImage: Int? = null,

--- a/libraries/dialogs/src/main/res/layout/fragment_dialog.xml
+++ b/libraries/dialogs/src/main/res/layout/fragment_dialog.xml
@@ -19,7 +19,9 @@
         <androidx.core.widget.NestedScrollView
             android:id="@+id/nestedScrollView"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:paddingStart="@dimen/ui_components_dialogs_margin_outer"
+            android:paddingEnd="@dimen/ui_components_dialogs_margin_outer">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/constraintLayout"

--- a/libraries/dialogs/src/main/res/layout/fragment_dialog.xml
+++ b/libraries/dialogs/src/main/res/layout/fragment_dialog.xml
@@ -17,10 +17,9 @@
             layout="@layout/layout_dialog_header"/>
 
         <androidx.core.widget.NestedScrollView
+            android:id="@+id/nestedScrollView"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingStart="@dimen/ui_components_dialogs_margin_outer"
-            android:paddingEnd="@dimen/ui_components_dialogs_margin_outer">
+            android:layout_height="wrap_content">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/constraintLayout"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Description
ScrollView of Dialog has default horizontal padding(16 dp) but custom dialog shouldn't have padding other than zero. With this feature, we can set padding for any dialog

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
