### PR TITLE
- Remove dataBinding from `:image-slider` component.

### DIFF
--- a/libraries/image-slider/build.gradle.kts
+++ b/libraries/image-slider/build.gradle.kts
@@ -28,7 +28,8 @@ android {
         }
     }
 
-    buildFeatures.dataBinding = true
+    buildFeatures.viewBinding = true
+    namespace = "com.trendyol.uicomponents.imageslider"
 }
 
 dependencies {

--- a/libraries/image-slider/src/main/AndroidManifest.xml
+++ b/libraries/image-slider/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.trendyol.uicomponents.imageslider" />

--- a/libraries/image-slider/src/main/java/com/trendyol/uicomponents/imageslider/Extensions.kt
+++ b/libraries/image-slider/src/main/java/com/trendyol/uicomponents/imageslider/Extensions.kt
@@ -4,36 +4,17 @@ import android.animation.ObjectAnimator
 import android.content.res.Resources
 import android.graphics.Point
 import android.graphics.drawable.ColorDrawable
-import android.view.*
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewPropertyAnimator
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.ImageView
-import androidx.annotation.LayoutRes
-import androidx.databinding.DataBindingUtil
-import androidx.databinding.ViewDataBinding
 import com.bumptech.glide.Glide
-import com.bumptech.glide.load.resource.bitmap.CenterCrop
-import com.bumptech.glide.load.resource.bitmap.FitCenter
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
-import com.bumptech.glide.request.RequestOptions
 import kotlin.math.pow
 import kotlin.math.sqrt
 
 internal fun Int.greaterThan(number: Int): Boolean = this > number
-
-internal fun <T : ViewDataBinding> ViewGroup?.inflate(
-    @LayoutRes layoutId: Int,
-    attachToParent: Boolean = true
-): T {
-    if (this?.isInEditMode == true) {
-        View.inflate(context, layoutId, parent as? ViewGroup?)
-    }
-    return DataBindingUtil.inflate(
-        LayoutInflater.from(this!!.context),
-        layoutId,
-        this,
-        attachToParent
-    )
-}
 
 fun ImageView.loadImage(imageUrl: String, cornerRadiusInDp: Double?) {
     val requestBuilder = Glide.with(context).load(imageUrl)
@@ -44,7 +25,7 @@ fun ImageView.loadImage(imageUrl: String, cornerRadiusInDp: Double?) {
     }.into(this)
 }
 
-internal val RETURN_ANIM_DURATION = 350
+internal const val RETURN_ANIM_DURATION = 350
 
 internal fun Point.getDifferenceVector(b: Point): Point {
     return Point(b.x - x, b.y - y)

--- a/libraries/image-slider/src/main/java/com/trendyol/uicomponents/imageslider/ImageSliderView.kt
+++ b/libraries/image-slider/src/main/java/com/trendyol/uicomponents/imageslider/ImageSliderView.kt
@@ -3,6 +3,7 @@ package com.trendyol.uicomponents.imageslider
 import android.app.Activity
 import android.content.Context
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.widget.FrameLayout
 import com.trendyol.uicomponents.imageslider.databinding.ViewImageSliderBinding
 import java.lang.ref.WeakReference
@@ -15,7 +16,7 @@ class ImageSliderView @JvmOverloads constructor(
     ImagesPagerAdapter.SliderAdapterItemClickListener,
     ImageSlider {
 
-    private var binding: ViewImageSliderBinding = inflate(R.layout.view_image_slider)
+    private var binding: ViewImageSliderBinding = ViewImageSliderBinding.inflate(LayoutInflater.from(context), this)
     private var hostActivityWeakReference: WeakReference<Activity> = WeakReference<Activity>(null)
     private var imageSliderViewListener: ImageSliderViewListener? = null
 
@@ -33,11 +34,10 @@ class ImageSliderView @JvmOverloads constructor(
     }
 
     fun setViewState(imageSliderViewState: ImageSliderViewState?) {
-        imageSliderViewState?.let {
-            binding.viewState = it
-            binding.executePendingBindings()
+        imageSliderViewState?.let { viewState ->
+            binding.indicatorImageSlider.visibility = viewState.getIndicatorVisibility()
 
-            setImages(imageSliderViewState)
+            setImages(viewState)
         }
     }
 

--- a/libraries/image-slider/src/main/java/com/trendyol/uicomponents/imageslider/ImagesPagerAdapter.kt
+++ b/libraries/image-slider/src/main/java/com/trendyol/uicomponents/imageslider/ImagesPagerAdapter.kt
@@ -6,11 +6,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.annotation.ColorInt
-import androidx.databinding.DataBindingUtil
 import androidx.viewpager.widget.PagerAdapter
 import com.trendyol.uicomponents.imageslider.databinding.ViewImageBinding
-import com.trendyol.uicomponents.touchdelegator.WindowTouchDelegator
 import com.trendyol.uicomponents.imageslider.touchdelegator.ZoomWindowTouchListener
+import com.trendyol.uicomponents.touchdelegator.WindowTouchDelegator
 import java.lang.ref.WeakReference
 
 class ImagesPagerAdapter(
@@ -46,12 +45,7 @@ class ImagesPagerAdapter(
     }
 
     override fun instantiateItem(collection: ViewGroup, position: Int): Any =
-        DataBindingUtil.inflate<ViewImageBinding>(
-            LayoutInflater.from(collection.context),
-            R.layout.view_image,
-            collection,
-            false
-        ).apply {
+        ViewImageBinding.inflate(LayoutInflater.from(collection.context), null, false).apply {
             binding = this
             collection.addView(linearLayoutSliderImageWrapper)
             imageViewSlider.scaleType = scaleType

--- a/libraries/image-slider/src/main/res/layout/view_image.xml
+++ b/libraries/image-slider/src/main/res/layout/view_image.xml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/linearLayoutSliderImageWrapper"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
 
-    <RelativeLayout
-        android:id="@+id/linearLayoutSliderImageWrapper"
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/imageViewSlider"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <androidx.appcompat.widget.AppCompatImageView
-            android:id="@+id/imageViewSlider"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_centerHorizontal="true"
-            android:clickable="true"
-            android:focusable="true" />
-    </RelativeLayout>
-</layout>
+        android:layout_height="match_parent"
+        android:layout_centerHorizontal="true"
+        android:clickable="true"
+        android:focusable="true" />
+</RelativeLayout>

--- a/libraries/image-slider/src/main/res/layout/view_image_slider.xml
+++ b/libraries/image-slider/src/main/res/layout/view_image_slider.xml
@@ -1,43 +1,32 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:parentTag="FrameLayout">
 
-    <data>
-
-        <variable
-            name="viewState"
-            type="com.trendyol.uicomponents.imageslider.ImageSliderViewState" />
-    </data>
-
-    <merge xmlns:android="http://schemas.android.com/apk/res/android"
+    <com.trendyol.uicomponents.imageslider.HackyViewPager
+        android:id="@+id/viewPager_image_slider"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:parentTag="FrameLayout">
+        android:layout_height="match_parent" />
 
-        <com.trendyol.uicomponents.imageslider.HackyViewPager
-            android:id="@+id/viewPager_image_slider"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-
-        <me.relex.circleindicator.CircleIndicator
-            android:id="@+id/indicator_image_slider"
-            android:layout_width="wrap_content"
-            android:layout_height="@dimen/indicator_height"
-            android:layout_gravity="center_horizontal|bottom"
-            android:layout_marginBottom="@dimen/indicator_margin_bottom"
-            android:background="@drawable/background_indicator"
-            android:paddingLeft="@dimen/indicator_padding_horizontal"
-            android:paddingTop="@dimen/indicator_padding_vertical"
-            android:paddingRight="@dimen/indicator_padding_horizontal"
-            android:paddingBottom="@dimen/indicator_padding_vertical"
-            android:visibility="@{viewState.indicatorVisibility}"
-            app:ci_animator="@animator/animator_alpha"
-            app:ci_animator_reverse="@animator/animator_alpha"
-            app:ci_drawable="@drawable/shape_indicator_selected"
-            app:ci_drawable_unselected="@drawable/shape_indicator_unselected"
-            app:ci_gravity="center_vertical"
-            app:ci_height="@dimen/indicator_size"
-            app:ci_orientation="horizontal"
-            app:ci_width="@dimen/indicator_size" />
-    </merge>
-</layout>
+    <me.relex.circleindicator.CircleIndicator
+        android:id="@+id/indicator_image_slider"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/indicator_height"
+        android:layout_gravity="center_horizontal|bottom"
+        android:layout_marginBottom="@dimen/indicator_margin_bottom"
+        android:background="@drawable/background_indicator"
+        android:paddingLeft="@dimen/indicator_padding_horizontal"
+        android:paddingTop="@dimen/indicator_padding_vertical"
+        android:paddingRight="@dimen/indicator_padding_horizontal"
+        android:paddingBottom="@dimen/indicator_padding_vertical"
+        app:ci_animator="@animator/animator_alpha"
+        app:ci_animator_reverse="@animator/animator_alpha"
+        app:ci_drawable="@drawable/shape_indicator_selected"
+        app:ci_drawable_unselected="@drawable/shape_indicator_unselected"
+        app:ci_gravity="center_vertical"
+        app:ci_height="@dimen/indicator_size"
+        app:ci_orientation="horizontal"
+        app:ci_width="@dimen/indicator_size" />
+</merge>


### PR DESCRIPTION
Update image-slider component to use `viewBinding`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Description
- Remove dataBinding from `:image-slider` component.
- Use `namespace` attribute and remove `AndroidManifest.xml`.

## How Has This Been Tested?
Tested on physical device.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
