### PR TITLE
get timelineItem layout width from view state getItemWidth method

### DIFF
--- a/libraries/timeline-view/README.md
+++ b/libraries/timeline-view/README.md
@@ -1,6 +1,6 @@
 <img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/timeline-view.png" width="240"/>
 
-timelineViewVersion = timeline-view-1.1.0 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+timelineViewVersion = timeline-view-1.1.1 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## TimelineView
 TimelineView creates a timeline and shows actions over time

--- a/libraries/timeline-view/src/main/java/com/trendyol/timelineview/TimelineItemAdapter.kt
+++ b/libraries/timeline-view/src/main/java/com/trendyol/timelineview/TimelineItemAdapter.kt
@@ -64,7 +64,7 @@ class TimelineItemAdapter(var timelineOrientation: TimelineOrientation = HORIZON
 
         fun bind(itemViewState: TimelineItemViewState) {
             with(binding) {
-                root.layoutParams = root.layoutParams.apply { width = itemViewState.lineWidth.toInt() }
+                root.layoutParams = root.layoutParams.apply { width = itemViewState.getItemWidth().toInt() }
                 with(viewStartLine) {
                     setBackgroundColor(itemViewState.getStartLineColor())
                     visibility = itemViewState.getStartLineVisibility()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
After the viewbinding migration, a ui bug was observed on the timeline views' item. A fix has been made for this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
the calculation of layout height of the item has been changed.

## Screenshots (if appropriate):
before
<img width="323" alt="image" src="https://user-images.githubusercontent.com/74511343/202103008-8a933d00-eab0-4166-9994-fc89c71bf2fb.png">
after
<img width="330" alt="image" src="https://user-images.githubusercontent.com/74511343/202102908-dc91c961-614a-441b-a2b2-aa98adda3e55.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
