### PR TITLE
Set WebView download listener separately

### DIFF
--- a/libraries/dialogs/README.md
+++ b/libraries/dialogs/README.md
@@ -44,7 +44,7 @@ Simple dialog to show information, error or text.
 | `contentImage`                  | Int                      | Drawable resource id of an visual, will be shown on top of `content`                                                      | 0             |
 | `webViewContent`                | WebViewContent           | If you provide a webview content such as Html data content or url , that will be shown in the webview.                    | null          |
 | `webViewBuilder`                | WebViewBuilder           | If you provide a webview content such as Html data content or url , necessary settings should we given via webViewBuilder | null          |
-| `webViewDownloadListener`       | DownloadListener         | If you need to handle download action in webview, you need to provide download listener to handle events                  | null          |
+| `webViewDownloadListener`       | DownloadListener         | If you need to handle download action in webview, you need to provide webViewDownloadListener to handle events            | null          |
   
 Sample usage:
  ```kotlin 

--- a/libraries/dialogs/README.md
+++ b/libraries/dialogs/README.md
@@ -1,7 +1,7 @@
 
 <img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-1.png" width="280"/> <img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-2.png" width="280"/> <img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-3.png" width="280"/> <img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-4.png" width="280"/> <img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/dialogs-5.png" width="280"/>
   
-$dialogsVersion = dialogs-1.4.1 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+$dialogsVersion = dialogs-1.4.2 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
   
 ## Dialogs  
 Dialogs is a bunch of BottomSheetDialogs to use in app to show user an information, agreement or list.  
@@ -44,6 +44,7 @@ Simple dialog to show information, error or text.
 | `contentImage`                  | Int                      | Drawable resource id of an visual, will be shown on top of `content`                                                      | 0             |
 | `webViewContent`                | WebViewContent           | If you provide a webview content such as Html data content or url , that will be shown in the webview.                    | null          |
 | `webViewBuilder`                | WebViewBuilder           | If you provide a webview content such as Html data content or url , necessary settings should we given via webViewBuilder | null          |
+| `webViewDownloadListener`       | DownloadListener         | If you need to handle download action in webview, you need to provide download listener to handle events                  | null          |
   
 Sample usage:
  ```kotlin 

--- a/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/Builder.kt
+++ b/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/Builder.kt
@@ -1,6 +1,7 @@
 package com.trendyol.uicomponents.dialogs
 
 import android.text.SpannableString
+import android.webkit.DownloadListener
 import android.webkit.WebView
 import androidx.annotation.DrawableRes
 
@@ -29,6 +30,7 @@ open class InfoDialogBuilder internal constructor() : Builder() {
     var webViewBuilder: (WebView.() -> Unit)? = null
     var horizontalPadding: Float? = null
     var verticalPadding: Float? = null
+    var webViewDownloadListener: DownloadListener? = null
 
     internal fun buildInfoDialog(block: InfoDialogBuilder.() -> Unit): DialogFragment {
         return InfoDialogBuilder().apply(block).let {
@@ -52,6 +54,7 @@ open class InfoDialogBuilder internal constructor() : Builder() {
                 ).toBundle()
                 this.closeButtonListener = it.closeButtonListener ?: { }
                 this.onDismissListener = it.onDialogDismissListener ?: {}
+                this.webViewDownloadListener = it.webViewDownloadListener
             }
         }
     }

--- a/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragment.kt
+++ b/libraries/dialogs/src/main/java/com/trendyol/uicomponents/dialogs/DialogFragment.kt
@@ -10,6 +10,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewOutlineProvider
+import android.webkit.DownloadListener
 import android.webkit.WebChromeClient
 import android.webkit.WebViewClient
 import androidx.core.widget.doAfterTextChanged
@@ -31,6 +32,7 @@ class DialogFragment internal constructor() : BaseBottomSheetDialog() {
     var onItemSelectedListener: ((DialogFragment, Int) -> Unit)? = null
     var onItemReselectedListener: ((DialogFragment, Int) -> Unit)? = null
     var onDismissListener: ((DialogFragment) -> Unit)? = null
+    var webViewDownloadListener: DownloadListener? = null
 
     internal lateinit var binding: FragmentDialogBinding
     private val dialogArguments by lazy(LazyThreadSafetyMode.NONE) {
@@ -237,6 +239,16 @@ class DialogFragment internal constructor() : BaseBottomSheetDialog() {
     override fun onDismiss(dialog: DialogInterface) {
         onDismissListener?.invoke(this@DialogFragment)
         super.onDismiss(dialog)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        binding.webViewContent.setDownloadListener(webViewDownloadListener)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        binding.webViewContent.setDownloadListener(null)
     }
 
     companion object {

--- a/sample/src/main/java/com/trendyol/uicomponents/DialogsActivity.kt
+++ b/sample/src/main/java/com/trendyol/uicomponents/DialogsActivity.kt
@@ -1,9 +1,14 @@
 package com.trendyol.uicomponents
 
+import android.app.DownloadManager
 import android.graphics.Color
+import android.net.Uri
 import android.os.Bundle
+import android.os.Environment
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
+import android.webkit.DownloadListener
+import android.webkit.URLUtil
 import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -24,6 +29,10 @@ class DialogsActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityDialogsBinding
 
+    private val downloadManager: DownloadManager? by lazy(LazyThreadSafetyMode.NONE) {
+        getSystemService(DOWNLOAD_SERVICE) as? DownloadManager
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityDialogsBinding.inflate(layoutInflater)
@@ -36,6 +45,9 @@ class DialogsActivity : AppCompatActivity() {
             buttonSelectionWithSearchDialog.setOnClickListener { showSelectionWithSearchDialog() }
             buttonInfoDialogWebview.setOnClickListener { showInfoDialogWithWebView() }
             buttonInfoListDialog.setOnClickListener { showInfoListDialog() }
+            buttonInfoDialogWithWebviewDownloadListener.setOnClickListener {
+                showInfoDialogWithWebViewDownloadListener()
+            }
         }
     }
 
@@ -160,6 +172,30 @@ class DialogsActivity : AppCompatActivity() {
                     R.drawable.shape_info_list_dialog_divider
                 )
             )
+        }.showDialog(supportFragmentManager)
+    }
+
+    private fun showInfoDialogWithWebViewDownloadListener() {
+        infoDialog {
+            title = "Info Dialog with WebView Download Listener"
+            webViewContent = WebViewContent.UrlContent("https://github.com/Trendyol")
+            showContentAsHtml = true
+            titleTextColor = R.color.civ_error_stroke
+            showCloseButton = true
+            webViewBuilder = {
+                settings.javaScriptEnabled = true
+            }
+            webViewDownloadListener = DownloadListener { url, _, contentDisposition, mimetype, _ ->
+                val downloadRequest = DownloadManager.Request(Uri.parse(url))
+                    .setTitle(title)
+                    .setMimeType(mimetype)
+                    .setDestinationInExternalPublicDir(
+                        Environment.DIRECTORY_DOWNLOADS,
+                        URLUtil.guessFileName(url, contentDisposition, mimetype)
+                    )
+                    .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+                downloadManager?.enqueue(downloadRequest)
+            }
         }.showDialog(supportFragmentManager)
     }
 

--- a/sample/src/main/res/layout/activity_dialogs.xml
+++ b/sample/src/main/res/layout/activity_dialogs.xml
@@ -81,4 +81,16 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/button_info_dialog_webview" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_info_dialog_with_webview_download_listener"
+        style="@style/Sample.ButtonStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:text="Show Info Dialog with WebView Download Listener"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button_info_list_dialog" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Set `DownloadListener` of `WebView` according to the `Dialog` lifecycle.

## Motivation and Context

We are getting a crash when the app gets in the background while the info dialog is on the screen. 👇 

`android.os.BadParcelableException: Parcelable encountered IOException writing serializable object (name = com.trendyol.uicomponents.DialogsActivity$showInfoDialogWithWebViewDownloadListener$1$1)`

I've seen a similar issue [here](https://github.com/Trendyol/android-ui-components/pull/94), the reason might be the same.

As a solution, I set the listener according to the dialog lifecycle 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
