### PR TITLE
Update Toolbar for RTL support

### DIFF
--- a/libraries/toolbar/README.md
+++ b/libraries/toolbar/README.md
@@ -1,6 +1,6 @@
-<img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/toolbar-1.png" width="240"/>
+<img src="https://raw.githubusercontent.com/Trendyol/android-ui-components/master/images/toolbar-1.png" width="240" alt:"Toolbar preview" />
 
-$toolbarVersion = toolbar-2.1.2  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+$toolbarVersion = toolbar-2.2.0  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Toolbar
 Toolbar is alternative implementation of Toolbar component on Android.
@@ -26,28 +26,32 @@ dependencies {
 
 To customize **Toolbar** you can set [ToolbarViewState](src/main/java/com/trendyol/uicomponents/toolbar/ToolbarViewState.kt) via calling `Toolbar.setViewState` or use attributes listed below. All given text attributes will be formatted as [HTML](https://developer.android.com/reference/android/text/Html).
 
-| Attribute | Description | Default Value | Sample Usage |
-| ------------- | ------------- | ------------- | ------------- |
-| `app:leftImageDrawable` | Left image drawable resource. | ic_arrow_back | `app:leftImageDrawable="@drawable/ic_back"` |
-| `app:middleImageDrawable` | Middle image drawable resource. | 0 | `app:middleImageDrawable="@drawable/ic_logo"` |
-| `app:rightImageDrawable` | Right image drawable resource. | 0 | `app:rightImageDrawable="@drawable/ic_close"` |
-| `app:upperLeftText` | Upper left text resource. | null | `app:upperLeftText="@string/list_title"` |
-| `app:lowerLeftText` | Lower left text resource. If upper left text is set and this is not set, upper left text would be centered vertically. | null | `app:lowerLeftText="@string/list_item_description"` |
-| `app:middleText` | Middle text resource. | null | `app:middleText="@string/app_name"` |
-| `app:upperRightText` | Upper right text resource. | null | `app:upperRightText="@string/action_select_all"` |
-| `app:lowerRightText` | Lower right text resource. If upper left text is set and this is not set, upper left text would be centered vertically. | null | `app:lowerRightText="@string/action_clear"` |
-| `app:toolbarBackground` | Background color or drawable resource. | android.R.color.white | `app:toolbarBackground="@drawable/toolbar_background"` |
-| `app:upperLeftTextMarginStart` | Start margin for upper left text. | trendyol_uicomponents_toolbar_margin_left_side_text | `app:upperLeftTextMarginStart="@dimen/trendyol_uicomponents_toolbar_margin_left_side_text"` |
-| `app:lowerLeftTextMarginStart` | Start margin for lower left text. | trendyol_uicomponents_toolbar_margin_left_side_text | `app:lowerLeftTextMarginStart="@dimen/trendyol_uicomponents_toolbar_margin_left_side_text"` |
-| `app:upperRightTextMarginEnd` | End margin for upper right text. | trendyol_uicomponents_toolbar_margin_outer | `app:upperLeftTextMarginStart="@dimen/trendyol_uicomponents_toolbar_margin_left_side_text"` |
-| `app:lowerRightTextMarginEnd` | End margin for upper right text. | trendyol_uicomponents_toolbar_margin_outer | `app:upperLeftTextMarginStart="@dimen/trendyol_uicomponents_toolbar_margin_left_side_text"` |
-| `app:leftImageDrawableMarginStart` | Start margin for left drawable. | 0 | `app:upperLeftTextMarginStart="@dimen/trendyol_uicomponents_toolbar_margin_left_side_text"` |
-| `app:rightImageDrawableMarginEnd` | End margin for left drawable. | 0 | `app:rightImageDrawableMarginEnd="@dimen/trendyol_uicomponents_toolbar_margin_right_side_icon"` |
-| `app:hideLeftImage` | Hide flag for left image. | false | `app:hideLeftImage="true"` |
-| `app:leftImageContentDescription` | Text for Left Image of Talkback | "" | `app:hideLeftImage="Back"` |
-| `app:rightImageContentDescription` | Text for Right Image of Talkback | "" | `app:hideLeftImage="Add"` |
-| `app:rightImageDrawableVerticalMargin` | Vertical margin for right drawable | 0 | `app:rightImageDrawableVerticalMargin="12dp"`|
-| `app:enableDotPoint` | Right drawable's dots point enabled status | false | `app:enableDotPoint="true"` |
+:warning: Starting from the `toolbar-2.2.0` version, namings are updated from "left-right" to
+"start-end" on both ToolbarViewState and resource attributes. Component will still support older
+values but its highly recommended to update usages.
+
+| Attribute                                                                       | Description                                                                                                               | Default Value                                               | Sample Usage                                           |
+|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|--------------------------------------------------------|
+| `app:StartImageDrawable` ~~`app:leftImageDrawable`~~                            | Start image drawable resource.                                                                                            | ic_arrow_back                                               | `app:startImageDrawable="@drawable/ic_back"`           |
+| `app:middleImageDrawable`                                                       | Middle image drawable resource.                                                                                           | 0                                                           | `app:middleImageDrawable="@drawable/ic_logo"`          |
+| `app:endImageDrawable` ~~`app:rightImageDrawable`~~                             | End image drawable resource.                                                                                              | 0                                                           | `app:endImageDrawable="@drawable/ic_close"`            |
+| `app:upperStartText` ~~`app:upperLeftText`~~                                    | Upper start text resource.                                                                                                | null                                                        | `app:upperStartText="@string/list_title"`              |
+| `app:lowerStartText` ~~`app:lowerLeftText`~~                                    | Lower start text resource. If upper start text is set and this is not set, upper start text would be centered vertically. | null                                                        | `app:lowerStartText="@string/list_item_description"`   |
+| `app:middleText`                                                                | Middle text resource.                                                                                                     | null                                                        | `app:middleText="@string/app_name"`                    |
+| `app:upperEndText` ~~`app:upperRightText`~~                                     | Upper end text resource.                                                                                                  | null                                                        | `app:upperE dText="@string/action_select_all"`         |
+| `app:lowerEndText` ~~`app:lowerRightText`~~                                     | Lower end text resource. If upper start text is set and this is not set, upper start text would be centered vertically.   | null                                                        | `app:lowerE dText="@string/action_clear"`              |
+| `app:toolbarBackground`                                                         | Background color or drawable resource.                                                                                    | android.R.color.white - #FFFFFF                             | `app:toolbarBackground="@drawable/toolbar_background"` |
+| `app:upperStartTextMarginStart` ~~`app:upperLeftTextMarginStart`~~              | Start margin for upper start text.                                                                                        | trendyol_uicomponents_toolbar_margin_start_side_text - 24dp | `app:upperStartTextMarginStart="@dimen/margin_sample"` |
+| `app:lowerStartTextMarginStart` ~~`app:lowerLeftTextMarginStart`~~              | Start margin for lower start text.                                                                                        | trendyol_uicomponents_toolbar_margin_start_side_text - 24dp | `app:lowerStartTextMarginStart="24dp"`                 |
+| `app:upperEndTextMarginEnd` ~~`app:upperRightTextMarginEnd`~~                   | End margin for upper end text.                                                                                            | trendyol_uicomponents_toolbar_margin_outer - 8dp            | `app:upperEndTextMarginEnd="@dimen/my_margin"`         |
+| `app:lowerEndTextMarginEnd` ~~`app:lowerRightTextMarginEnd`~~                   | End margin for upper end text.                                                                                            | trendyol_uicomponents_toolbar_margin_outer - 8dp            | `app:lowerEndTextMarginEnd="16dp"`                     |
+| `app:startImageDrawableMarginStart` ~~`app:leftImageDrawableMarginStart`~~      | Start margin for start drawable.                                                                                          | 0                                                           | `app:startImageDrawableMarginStart="@dimen/my_margin"` |
+| `app:endImageDrawableMarginEnd` ~~`app:rightImageDrawableMarginEnd`~~           | End margin for start drawable.                                                                                            | 0                                                           | `app:endImageDrawableMarginEnd="32dp"`                 |
+| `app:hideStartImage` ~~`app:hideLeftImage`~~                                    | Hide flag for start image.                                                                                                | false                                                       | `app:hideStartImage="true"`                            |
+| `app:startImageContentDescription` ~~`app:leftImageContentDescription`~~        | Text for start Image of Talkback                                                                                          | ""                                                          | `app:startImageContentDescription="Back"`              |
+| `app:endImageContentDescription` ~~`app:rightImageContentDescription`~~         | Text for end Image of Talkback                                                                                            | ""                                                          | `app:endImageContentDescription="Add"`                 |
+| `app:endImageDrawableVerticalMargin` ~~`app:rightImageDrawableVerticalMargin`~~ | Vertical margin for end drawable                                                                                          | 0                                                           | `app:endImageDrawableVerticalMargin="12dp"`            |
+| `app:enableDotPoint`                                                            | End drawable's dots point enabled status                                                                                  | false                                                       | `app:enableDotPoint="true"`                            |
 
 Sample usage with attributes:
 
@@ -59,7 +63,7 @@ Sample usage with attributes:
         android:layout_height="?attr/actionBarSize"
         app:toolbarBackground="@color/background"
         app:middleText="@string/app_name"
-        app:upperRightText="@string/clear_all" />
+        app:upperEndText="@string/clear_all" />
 
 ```
 
@@ -73,7 +77,7 @@ To set click listener, you can use **Toolbar** instance fields like below.
 
     val toolbar: Toolbar = findViewById(R.id.toolbar)
     
-    toolbar.leftImageClickListener = { onBackPressed() }
+    toolbar.startImageClickListener = { onBackPressed() }
 
 ```
 
@@ -84,9 +88,9 @@ Sample usage with `ToolbarViewState`:
     val toolbar: Toolbar = findViewById(R.id.toolbar)
     
     toolbar.viewState = ToolbarViewState(
-        upperLeftText = "<b>List</b>",
-        leftImageDrawableResId = R.drawable.ic_arrow_back,
-        upperLeftTextAppearance = R.style.MyTextStyle_Body_2
+        upperStartText = "<b>List</b>",
+        startImageDrawableResId = R.drawable.ic_arrow_back,
+        upperStartTextAppearance = R.style.MyTextStyle_Body_2
     )
 
 ```

--- a/libraries/toolbar/build.gradle.kts
+++ b/libraries/toolbar/build.gradle.kts
@@ -23,6 +23,13 @@ android {
         }
     }
 
+    publishing {
+        this.singleVariant("release") {
+            withJavadocJar()
+            withSourcesJar()
+        }
+    }
+
     namespace = "com.trendyol.uicomponents.toolbar"
 }
 

--- a/libraries/toolbar/src/main/java/com/trendyol/uicomponents/toolbar/Extensions.kt
+++ b/libraries/toolbar/src/main/java/com/trendyol/uicomponents/toolbar/Extensions.kt
@@ -1,10 +1,13 @@
 package com.trendyol.uicomponents.toolbar
 
+import android.content.res.TypedArray
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
+import androidx.annotation.StyleableRes
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.widget.TextViewCompat
 
@@ -54,4 +57,45 @@ fun View.setDebouncedOnClickListener(debounceMillis: Long = 500L, onClickListene
             onClickListener.onClick(view)
         }
     }
+}
+
+internal fun TypedArray.getDimensionPixelOffsetOrDefault(
+    @StyleableRes primaryIndex: Int,
+    @StyleableRes secondaryIndex: Int,
+    defaultValue: Int,
+): Int {
+    val primaryValue = getDimensionPixelOffset(primaryIndex, -1)
+    val secondaryValue = getDimensionPixelOffset(secondaryIndex, -1)
+    return if (primaryValue == -1 && secondaryValue == -1) {
+        defaultValue
+    } else if (primaryValue == -1) {
+        secondaryValue
+    } else {
+        primaryValue
+    }
+}
+
+internal fun TypedArray.getResourceIdOrDefault(
+    @StyleableRes primaryIndex: Int,
+    @StyleableRes secondaryIndex: Int,
+    defaultValue: Int
+): Int {
+    val primaryValue = getResourceId(primaryIndex, 0)
+    val secondaryValue = getResourceId(secondaryIndex, 0)
+    return if (primaryValue == 0 && secondaryValue == 0) {
+        defaultValue
+    } else if (primaryValue == 0) {
+        secondaryValue
+    } else {
+        primaryValue
+    }
+}
+
+internal fun TypedArray.getStringOrEmpty(
+    @StyleableRes primaryIndex: Int,
+    @StyleableRes secondaryIndex: Int,
+): String {
+    val primaryValue = getString(primaryIndex)
+    val secondaryValue = getString(secondaryIndex)
+    return primaryValue ?: secondaryValue ?: ""
 }

--- a/libraries/toolbar/src/main/java/com/trendyol/uicomponents/toolbar/Toolbar.kt
+++ b/libraries/toolbar/src/main/java/com/trendyol/uicomponents/toolbar/Toolbar.kt
@@ -5,8 +5,8 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
-import com.trendyol.uicomponents.toolbar.databinding.ViewToolbarBinding
 import androidx.core.view.isVisible
+import com.trendyol.uicomponents.toolbar.databinding.ViewToolbarBinding
 
 class Toolbar : ConstraintLayout {
 
@@ -19,13 +19,38 @@ class Toolbar : ConstraintLayout {
             applyViewState()
         }
 
+    var startImageClickListener: (() -> Unit)? = null
+
+    @Deprecated("Replaced with startImageClickListener", replaceWith = ReplaceWith("startImageClickListener"))
     var leftImageClickListener: (() -> Unit)? = null
+
     var middleImageClickListener: (() -> Unit)? = null
+
+    var endImageClickListener: (() -> Unit)? = null
+
+    @Deprecated("Replaced with endImageClickListener", replaceWith = ReplaceWith("endImageClickListener"))
     var rightImageClickListener: (() -> Unit)? = null
+
+    var upperStartTextClickListener: (() -> Unit)? = null
+
+    @Deprecated("Replaced with upperStartTextClickListener", replaceWith = ReplaceWith("upperStartTextClickListener"))
     var upperLeftTextClickListener: (() -> Unit)? = null
+
+    var lowerStartTextClickListener: (() -> Unit)? = null
+
+    @Deprecated("Replaced with lowerStartTextClickListener", replaceWith = ReplaceWith("lowerStartTextClickListener"))
     var lowerLeftTextClickListener: (() -> Unit)? = null
+
     var middleTextClickListener: (() -> Unit)? = null
+
+    var upperEndTextClickListener: (() -> Unit)? = null
+
+    @Deprecated("Replaced with upperEndTextClickListener", replaceWith = ReplaceWith("upperEndTextClickListener"))
     var upperRightTextClickListener: (() -> Unit)? = null
+
+    var lowerEndTextClickListener: (() -> Unit)? = null
+
+    @Deprecated("Replaced with lowerEndTextClickListener", replaceWith = ReplaceWith("lowerEndTextClickListener"))
     var lowerRightTextClickListener: (() -> Unit)? = null
 
     constructor(context: Context) : super(context)
@@ -43,14 +68,32 @@ class Toolbar : ConstraintLayout {
     }
 
     init {
-        binding.imageLeft.setOnClickListener { leftImageClickListener?.invoke() }
+        binding.imageLeft.setOnClickListener {
+            startImageClickListener?.invoke()
+            leftImageClickListener?.invoke()
+        }
         binding.imageMiddle.setOnClickListener { middleImageClickListener?.invoke() }
-        binding.imageRight.setDebouncedOnClickListener { rightImageClickListener?.invoke() }
-        binding.textLeftUp.setOnClickListener { upperLeftTextClickListener?.invoke() }
-        binding.textLeftDown.setOnClickListener { lowerLeftTextClickListener?.invoke() }
+        binding.imageRight.setDebouncedOnClickListener {
+            endImageClickListener?.invoke()
+            rightImageClickListener?.invoke()
+        }
+        binding.textLeftUp.setOnClickListener {
+            upperStartTextClickListener?.invoke()
+            upperLeftTextClickListener?.invoke()
+        }
+        binding.textLeftDown.setOnClickListener {
+            lowerStartTextClickListener?.invoke()
+            lowerLeftTextClickListener?.invoke()
+        }
         binding.textMiddle.setOnClickListener { middleTextClickListener?.invoke() }
-        binding.textRightUp.setOnClickListener { upperRightTextClickListener?.invoke() }
-        binding.textRightDown.setOnClickListener { lowerRightTextClickListener?.invoke() }
+        binding.textRightUp.setOnClickListener {
+            upperEndTextClickListener?.invoke()
+            upperRightTextClickListener?.invoke()
+        }
+        binding.textRightDown.setOnClickListener {
+            lowerEndTextClickListener?.invoke()
+            lowerRightTextClickListener?.invoke()
+        }
     }
 
     private fun readFromAttributes(attrs: AttributeSet?, defStyleAttr: Int = 0) {
@@ -60,83 +103,102 @@ class Toolbar : ConstraintLayout {
             defStyleAttr,
             0
         )?.apply {
-            val toolbarBackground =
-                getResourceId(R.styleable.Toolbar_toolbarBackground, android.R.color.white)
-            val leftImageDrawableResId =
-                getResourceId(
-                    R.styleable.Toolbar_leftImageDrawable,
-                    R.drawable.trendyol_uicomponents_toolbar_arrow_back
-                )
+            val toolbarBackground = getResourceId(R.styleable.Toolbar_toolbarBackground, android.R.color.white)
+            val startImageDrawableResId = getResourceIdOrDefault(
+                R.styleable.Toolbar_startImageDrawable,
+                R.styleable.Toolbar_leftImageDrawable,
+                R.drawable.trendyol_uicomponents_toolbar_arrow_back
+            )
             val middleImageDrawableResId = getResourceId(R.styleable.Toolbar_middleImageDrawable, 0)
-            val rightImageDrawableResId = getResourceId(R.styleable.Toolbar_rightImageDrawable, 0)
+            val endImageDrawableResId = getResourceIdOrDefault(
+                R.styleable.Toolbar_endImageDrawable,
+                R.styleable.Toolbar_rightImageDrawable,
+                0
+            )
 
-            val upperLeftText = getString(R.styleable.Toolbar_upperLeftText)
-            val lowerLeftText = getString(R.styleable.Toolbar_lowerLeftText)
+            val upperStartText = getString(R.styleable.Toolbar_upperStartText)
+                ?: getString(R.styleable.Toolbar_upperLeftText)
+            val lowerStartText = getString(R.styleable.Toolbar_lowerStartText)
+                ?: getString(R.styleable.Toolbar_lowerLeftText)
             val middleText = getString(R.styleable.Toolbar_middleText)
-            val upperRightText = getString(R.styleable.Toolbar_upperRightText)
-            val lowerRightText = getString(R.styleable.Toolbar_lowerRightText)
+            val upperEndText = getString(R.styleable.Toolbar_upperEndText)
+                ?: getString(R.styleable.Toolbar_upperRightText)
+            val lowerEndText = getString(R.styleable.Toolbar_lowerEndText)
+                ?: getString(R.styleable.Toolbar_lowerRightText)
 
-            val leftTextDefaultMarginStart =
-                resources.getDimensionPixelOffset(R.dimen.trendyol_uicomponents_toolbar_margin_left_side_text)
-            val rightTextDefaultMarginEnd =
+            val startTextDefaultMarginStart =
+                resources.getDimensionPixelOffset(R.dimen.trendyol_uicomponents_toolbar_margin_start_side_text)
+            val endTextDefaultMarginEnd =
                 resources.getDimensionPixelOffset(R.dimen.trendyol_uicomponents_toolbar_margin_outer)
 
-            val upperLeftTextMarginStart =
-                getDimensionPixelOffset(
-                    R.styleable.Toolbar_upperLeftTextMarginStart,
-                    leftTextDefaultMarginStart
-                )
-            val lowerLeftTextMarginStart =
-                getDimensionPixelOffset(
-                    R.styleable.Toolbar_lowerLeftTextMarginStart,
-                    leftTextDefaultMarginStart
-                )
-
-            val upperRightTextMarginEnd =
-                getDimensionPixelOffset(
-                    R.styleable.Toolbar_upperRightTextMarginEnd,
-                    rightTextDefaultMarginEnd
-                )
-            val lowerRightTextMarginEnd =
-                getDimensionPixelOffset(
-                    R.styleable.Toolbar_lowerRightTextMarginEnd,
-                    rightTextDefaultMarginEnd
-                )
-            val rightImageDrawableMarginEnd =
-                getDimensionPixelOffset(R.styleable.Toolbar_rightImageDrawableMarginEnd, 0)
-            val rightImageDrawableVerticalMargin =
-                getDimensionPixelOffset(R.styleable.Toolbar_rightImageDrawableVerticalMargin, 0)
-            val enableDotPoint =
-                getBoolean(R.styleable.Toolbar_enableDotPoint, false)
-            val leftImageDrawableMarginStart =
-                getDimensionPixelOffset(R.styleable.Toolbar_leftImageDrawableMarginStart, 0)
-            val hideLeftImage = getBoolean(R.styleable.Toolbar_hideLeftImage, false)
-            val leftImageContentDescription =
-                getString(R.styleable.Toolbar_leftImageContentDescription) ?: ""
-            val rightImageContentDescription =
-                getString(R.styleable.Toolbar_rightImageContentDescription) ?: ""
+            val upperStartTextMarginStart = getDimensionPixelOffsetOrDefault(
+                R.styleable.Toolbar_upperStartTextMarginStart,
+                R.styleable.Toolbar_upperLeftTextMarginStart,
+                startTextDefaultMarginStart
+            )
+            val lowerStartTextMarginStart = getDimensionPixelOffsetOrDefault(
+                R.styleable.Toolbar_lowerStartTextMarginStart,
+                R.styleable.Toolbar_lowerLeftTextMarginStart,
+                startTextDefaultMarginStart
+            )
+            val upperEndTextMarginEnd = getDimensionPixelOffsetOrDefault(
+                R.styleable.Toolbar_upperEndTextMarginEnd,
+                R.styleable.Toolbar_upperRightTextMarginEnd,
+                endTextDefaultMarginEnd
+            )
+            val lowerEndTextMarginEnd = getDimensionPixelOffsetOrDefault(
+                R.styleable.Toolbar_lowerEndTextMarginEnd,
+                R.styleable.Toolbar_lowerRightTextMarginEnd,
+                endTextDefaultMarginEnd
+            )
+            val endImageDrawableMarginEnd = getDimensionPixelOffsetOrDefault(
+                R.styleable.Toolbar_endImageDrawableMarginEnd,
+                R.styleable.Toolbar_rightImageDrawableMarginEnd,
+                0
+            )
+            val endImageDrawableVerticalMargin = getDimensionPixelOffsetOrDefault(
+                R.styleable.Toolbar_endImageDrawableVerticalMargin,
+                R.styleable.Toolbar_rightImageDrawableVerticalMargin,
+                0
+            )
+            val enableDotPoint = getBoolean(R.styleable.Toolbar_enableDotPoint, false)
+            val startImageDrawableMarginStart = getDimensionPixelOffsetOrDefault(
+                R.styleable.Toolbar_startImageDrawableMarginStart,
+                R.styleable.Toolbar_leftImageDrawableMarginStart,
+                0
+            )
+            val hideStartImage = (getBoolean(R.styleable.Toolbar_hideStartImage, false)
+                || getBoolean(R.styleable.Toolbar_hideLeftImage, false))
+            val startImageContentDescription = getStringOrEmpty(
+                R.styleable.Toolbar_startImageContentDescription,
+                R.styleable.Toolbar_leftImageContentDescription
+            )
+            val endImageContentDescription = getStringOrEmpty(
+                R.styleable.Toolbar_endImageContentDescription,
+                R.styleable.Toolbar_rightImageContentDescription
+            )
 
             viewState = ToolbarViewState(
-                upperLeftText = upperLeftText,
-                lowerLeftText = lowerLeftText,
+                upperStartText = upperStartText,
+                lowerStartText = lowerStartText,
                 middleText = middleText,
-                upperRightText = upperRightText,
-                lowerRightText = lowerRightText,
-                leftImageDrawableResId = leftImageDrawableResId,
+                upperEndText = upperEndText,
+                lowerEndText = lowerEndText,
+                startImageDrawableResId = startImageDrawableResId,
                 middleImageDrawableResId = middleImageDrawableResId,
-                rightImageDrawableResId = rightImageDrawableResId,
+                endImageDrawableResId = endImageDrawableResId,
                 toolbarBackground = toolbarBackground,
-                upperLeftTextMarginStartInPixel = upperLeftTextMarginStart,
-                lowerLeftTextMarginStartInPixel = lowerLeftTextMarginStart,
-                upperRightTextMarginEndInPixel = upperRightTextMarginEnd,
-                lowerRightTextMarginEndInPixel = lowerRightTextMarginEnd,
-                rightImageDrawableMarginEndInPixel = rightImageDrawableMarginEnd,
-                leftImageDrawableMarginStartInPixel = leftImageDrawableMarginStart,
-                rightImageDrawableVerticalMarginInPixel = rightImageDrawableVerticalMargin,
+                upperStartTextMarginStartInPixel = upperStartTextMarginStart,
+                lowerStartTextMarginStartInPixel = lowerStartTextMarginStart,
+                upperEndTextMarginEndInPixel = upperEndTextMarginEnd,
+                lowerEndTextMarginEndInPixel = lowerEndTextMarginEnd,
+                endImageDrawableMarginEndInPixel = endImageDrawableMarginEnd,
+                startImageDrawableMarginStartInPixel = startImageDrawableMarginStart,
+                endImageDrawableVerticalMarginInPixel = endImageDrawableVerticalMargin,
                 enableDotPoint = enableDotPoint,
-                hideLeftImage = hideLeftImage,
-                leftImageContentDescription = leftImageContentDescription,
-                rightImageContentDescription = rightImageContentDescription
+                hideStartImage = hideStartImage,
+                startImageContentDescription = startImageContentDescription,
+                endImageContentDescription = endImageContentDescription
             )
         }
     }
@@ -145,44 +207,44 @@ class Toolbar : ConstraintLayout {
         with(viewState) {
             binding.imageBackground.setDrawableResource(toolbarBackground)
 
-            binding.imageLeft.setDrawableResource(leftImageDrawableResId)
-            binding.imageLeft.setStartMargin(leftImageDrawableMarginStartInPixel)
-            binding.imageLeft.visibility = if (hideLeftImage) View.GONE else View.VISIBLE
-            binding.imageLeft.contentDescription = leftImageContentDescription
+            binding.imageLeft.setDrawableResource(startImageDrawableResId)
+            binding.imageLeft.setStartMargin(startImageDrawableMarginStartInPixel)
+            binding.imageLeft.visibility = if (hideStartImage) View.GONE else View.VISIBLE
+            binding.imageLeft.contentDescription = startImageContentDescription
 
             binding.imageMiddle.setDrawableResource(middleImageDrawableResId)
 
-            binding.imageRight.setDrawableResource(rightImageDrawableResId)
-            binding.imageRight.setEndMargin(rightImageDrawableMarginEndInPixel)
-            binding.imageRight.contentDescription = rightImageContentDescription
-            binding.imageRight.setVerticalPadding(rightImageDrawableVerticalMarginInPixel)
+            binding.imageRight.setDrawableResource(endImageDrawableResId)
+            binding.imageRight.setEndMargin(endImageDrawableMarginEndInPixel)
+            binding.imageRight.contentDescription = endImageContentDescription
+            binding.imageRight.setVerticalPadding(endImageDrawableVerticalMarginInPixel)
 
             binding.imageViewDot.isVisible = enableDotPoint
 
-            binding.textLeftUp.text = upperLeftTextValue
-            binding.textLeftUp.visibility = upperLeftTextVisibility
-            binding.textLeftUp.setStyle(upperLeftTextAppearance)
-            binding.textLeftUp.setStartMargin(upperLeftTextMarginStartInPixel)
+            binding.textLeftUp.text = upperStartTextValue
+            binding.textLeftUp.visibility = upperStartTextVisibility
+            binding.textLeftUp.setStyle(upperStartTextAppearance)
+            binding.textLeftUp.setStartMargin(upperStartTextMarginStartInPixel)
 
-            binding.textLeftDown.text = lowerLeftTextValue
-            binding.textLeftDown.visibility = lowerLeftTextVisibility
-            binding.textLeftDown.setStyle(lowerLeftTextAppearance)
-            binding.textLeftDown.setStartMargin(lowerLeftTextMarginStartInPixel)
+            binding.textLeftDown.text = lowerStartTextValue
+            binding.textLeftDown.visibility = lowerStartTextVisibility
+            binding.textLeftDown.setStyle(lowerStartTextAppearance)
+            binding.textLeftDown.setStartMargin(lowerStartTextMarginStartInPixel)
 
             binding.textMiddle.text = middleTextValue
             binding.textMiddle.visibility = middleTextVisibility
             binding.textMiddle.setStyle(middleTextAppearance)
 
-            binding.textRightUp.text = upperRightTextValue
-            binding.textRightUp.visibility = upperRightTextVisibility
-            binding.textRightUp.setStyle(upperRightTextAppearance)
-            binding.textRightUp.setEndMargin(upperRightTextMarginEndInPixel)
-            binding.textRightUp.isEnabled = isUpperRightTextEnabled
+            binding.textRightUp.text = upperEndTextValue
+            binding.textRightUp.visibility = upperEndTextVisibility
+            binding.textRightUp.setStyle(upperEndTextAppearance)
+            binding.textRightUp.setEndMargin(upperEndTextMarginEndInPixel)
+            binding.textRightUp.isEnabled = isUpperEndTextEnabled
 
-            binding.textRightDown.text = lowerRightTextValue
-            binding.textRightDown.visibility = lowerRightTextVisibility
+            binding.textRightDown.text = lowerEndTextValue
+            binding.textRightDown.visibility = lowerEndTextVisibility
             binding.textRightDown.setStyle(lowerRightTextAppearance)
-            binding.textRightDown.setEndMargin(lowerRightTextMarginEndInPixel)
+            binding.textRightDown.setEndMargin(lowerEndTextMarginEndInPixel)
         }
     }
 }

--- a/libraries/toolbar/src/main/java/com/trendyol/uicomponents/toolbar/ToolbarViewState.kt
+++ b/libraries/toolbar/src/main/java/com/trendyol/uicomponents/toolbar/ToolbarViewState.kt
@@ -7,48 +7,109 @@ import androidx.annotation.Px
 import androidx.annotation.StyleRes
 import androidx.core.text.HtmlCompat
 
-data class ToolbarViewState(
-    val upperLeftText: CharSequence? = null,
-    val lowerLeftText: CharSequence? = null,
+data class ToolbarViewState
+constructor(
+    val upperStartText: CharSequence? = null,
+    val lowerStartText: CharSequence? = null,
     val middleText: CharSequence? = null,
-    val upperRightText: CharSequence? = null,
-    val lowerRightText: CharSequence? = null,
-    @DrawableRes val leftImageDrawableResId: Int = R.drawable.trendyol_uicomponents_toolbar_arrow_back,
+    val upperEndText: CharSequence? = null,
+    val lowerEndText: CharSequence? = null,
+    @DrawableRes val startImageDrawableResId: Int = R.drawable.trendyol_uicomponents_toolbar_arrow_back,
     @DrawableRes val middleImageDrawableResId: Int = 0,
-    @DrawableRes val rightImageDrawableResId: Int = 0,
-    @StyleRes val upperLeftTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_UpperAction,
-    @StyleRes val lowerLeftTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_LowerAction,
+    @DrawableRes val endImageDrawableResId: Int = 0,
+    @StyleRes val upperStartTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_UpperAction,
+    @StyleRes val lowerStartTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_LowerAction,
     @StyleRes val middleTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_UpperAction,
-    @StyleRes val upperRightTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_UpperAction,
+    @StyleRes val upperEndTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_UpperAction,
     @StyleRes val lowerRightTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_LowerAction,
-    @StyleRes val upperRightTextDisabledAppearance: Int =
-        R.style.Trendyol_UIComponents_Toolbar_Text_UpperAction_Disabled,
+    @StyleRes val lowerEndTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_LowerAction,
     @DrawableRes val toolbarBackground: Int = android.R.color.white,
-    @Px val upperLeftTextMarginStartInPixel: Int? = null,
-    @Px val lowerLeftTextMarginStartInPixel: Int? = null,
-    @Px val upperRightTextMarginEndInPixel: Int? = null,
-    @Px val lowerRightTextMarginEndInPixel: Int? = null,
-    @Px val rightImageDrawableMarginEndInPixel: Int? = null,
-    @Px val leftImageDrawableMarginStartInPixel: Int? = null,
-    @Px val rightImageDrawableVerticalMarginInPixel: Int? = null,
+    @Px val upperStartTextMarginStartInPixel: Int? = null,
+    @Px val lowerStartTextMarginStartInPixel: Int? = null,
+    @Px val upperEndTextMarginEndInPixel: Int? = null,
+    @Px val lowerEndTextMarginEndInPixel: Int? = null,
+    @Px val endImageDrawableMarginEndInPixel: Int? = null,
+    @Px val startImageDrawableMarginStartInPixel: Int? = null,
+    @Px val endImageDrawableVerticalMarginInPixel: Int? = null,
     val enableDotPoint: Boolean = false,
-    val isUpperRightTextEnabled: Boolean = true,
-    val hideLeftImage: Boolean = false,
-    val leftImageContentDescription: String = "",
-    val rightImageContentDescription: String = ""
+    val isUpperEndTextEnabled: Boolean = true,
+    val hideStartImage: Boolean = false,
+    val startImageContentDescription: String = "",
+    val endImageContentDescription: String = "",
 ) {
 
-    internal val upperLeftTextVisibility: Int = getFieldVisibility(upperLeftText)
-    internal val lowerLeftTextVisibility: Int = getFieldVisibility(lowerLeftText)
-    internal val middleTextVisibility: Int = getFieldVisibility(middleText)
-    internal val upperRightTextVisibility: Int = getFieldVisibility(upperRightText)
-    internal val lowerRightTextVisibility: Int = getFieldVisibility(lowerRightText)
+    @Deprecated(message = "Use constructor with start - end namings")
+    constructor(
+        upperLeftText: CharSequence? = null,
+        lowerLeftText: CharSequence? = null,
+        middleText: CharSequence? = null,
+        upperRightText: CharSequence? = null,
+        lowerRightText: CharSequence? = null,
+        @DrawableRes leftImageDrawableResId: Int = R.drawable.trendyol_uicomponents_toolbar_arrow_back,
+        @DrawableRes middleImageDrawableResId: Int = 0,
+        @DrawableRes rightImageDrawableResId: Int = 0,
+        @StyleRes upperLeftTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_UpperAction,
+        @StyleRes lowerLeftTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_LowerAction,
+        @StyleRes middleTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_UpperAction,
+        @StyleRes upperRightTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_UpperAction,
+        @StyleRes lowerRightTextAppearance: Int = R.style.Trendyol_UIComponents_Toolbar_Text_LowerAction,
+        @StyleRes upperRightTextDisabledAppearance: Int =
+            R.style.Trendyol_UIComponents_Toolbar_Text_UpperAction_Disabled,
+        @DrawableRes toolbarBackground: Int = android.R.color.white,
+        @Px upperLeftTextMarginStartInPixel: Int? = null,
+        @Px lowerLeftTextMarginStartInPixel: Int? = null,
+        @Px upperRightTextMarginEndInPixel: Int? = null,
+        @Px lowerRightTextMarginEndInPixel: Int? = null,
+        @Px rightImageDrawableMarginEndInPixel: Int? = null,
+        @Px leftImageDrawableMarginStartInPixel: Int? = null,
+        @Px rightImageDrawableVerticalMarginInPixel: Int? = null,
+        enableDotPoint: Boolean = false,
+        isUpperRightTextEnabled: Boolean = true,
+        hideLeftImage: Boolean = false,
+        leftImageContentDescription: String = "",
+        rightImageContentDescription: String = "",
+        ignored: Int = 0 // Fixes conflicting constructor overload
+    ) : this(
+        upperStartText = upperLeftText,
+        lowerStartText = lowerLeftText,
+        middleText = middleText,
+        upperEndText = upperRightText,
+        lowerEndText = lowerRightText,
+        startImageDrawableResId = leftImageDrawableResId,
+        middleImageDrawableResId = middleImageDrawableResId,
+        endImageDrawableResId = rightImageDrawableResId,
+        upperStartTextAppearance = upperLeftTextAppearance,
+        lowerStartTextAppearance = lowerLeftTextAppearance,
+        middleTextAppearance = middleTextAppearance,
+        upperEndTextAppearance = upperRightTextAppearance,
+        lowerRightTextAppearance = lowerRightTextAppearance,
+        lowerEndTextAppearance = upperRightTextDisabledAppearance,
+        toolbarBackground = toolbarBackground,
+        upperStartTextMarginStartInPixel = upperLeftTextMarginStartInPixel,
+        lowerStartTextMarginStartInPixel = lowerLeftTextMarginStartInPixel,
+        upperEndTextMarginEndInPixel = upperRightTextMarginEndInPixel,
+        lowerEndTextMarginEndInPixel = lowerRightTextMarginEndInPixel,
+        endImageDrawableMarginEndInPixel = rightImageDrawableMarginEndInPixel,
+        startImageDrawableMarginStartInPixel = leftImageDrawableMarginStartInPixel,
+        endImageDrawableVerticalMarginInPixel = rightImageDrawableVerticalMarginInPixel,
+        enableDotPoint = enableDotPoint,
+        isUpperEndTextEnabled = isUpperRightTextEnabled,
+        hideStartImage = hideLeftImage,
+        startImageContentDescription = leftImageContentDescription,
+        endImageContentDescription = rightImageContentDescription,
+    )
 
-    internal val upperLeftTextValue: Spanned? = upperLeftText?.let(::getTextAsSpanned)
-    internal val lowerLeftTextValue: Spanned? = lowerLeftText?.let(::getTextAsSpanned)
+    internal val upperStartTextVisibility: Int = getFieldVisibility(upperStartText)
+    internal val lowerStartTextVisibility: Int = getFieldVisibility(lowerStartText)
+    internal val middleTextVisibility: Int = getFieldVisibility(middleText)
+    internal val upperEndTextVisibility: Int = getFieldVisibility(upperEndText)
+    internal val lowerEndTextVisibility: Int = getFieldVisibility(lowerEndText)
+
+    internal val upperStartTextValue: Spanned? = upperStartText?.let(::getTextAsSpanned)
+    internal val lowerStartTextValue: Spanned? = lowerStartText?.let(::getTextAsSpanned)
     internal val middleTextValue: Spanned? = middleText?.let(::getTextAsSpanned)
-    internal val upperRightTextValue: Spanned? = upperRightText?.let(::getTextAsSpanned)
-    internal val lowerRightTextValue: Spanned? = lowerRightText?.let(::getTextAsSpanned)
+    internal val upperEndTextValue: Spanned? = upperEndText?.let(::getTextAsSpanned)
+    internal val lowerEndTextValue: Spanned? = lowerEndText?.let(::getTextAsSpanned)
 
     private fun getFieldVisibility(fieldValue: CharSequence?) = if (fieldValue == null) View.GONE else View.VISIBLE
 

--- a/libraries/toolbar/src/main/res/layout/view_toolbar.xml
+++ b/libraries/toolbar/src/main/res/layout/view_toolbar.xml
@@ -28,7 +28,7 @@
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/textLeftUp"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:layout_marginEnd="@dimen/trendyol_uicomponents_toolbar_margin_outer"
         android:ellipsize="end"
@@ -40,12 +40,14 @@
         app:layout_constraintHorizontal_bias="0"
         app:layout_constraintStart_toEndOf="@id/imageLeft"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="Left Action"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:layout_marginStart="@dimen/trendyol_uicomponents_toolbar_margin_start_side_text"
+        tools:text="Start Action"
         tools:visibility="visible" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/textLeftDown"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:layout_marginEnd="@dimen/trendyol_uicomponents_toolbar_margin_outer"
         android:ellipsize="end"
@@ -57,7 +59,8 @@
         app:layout_constraintHorizontal_bias="0"
         app:layout_constraintStart_toEndOf="@id/imageLeft"
         app:layout_constraintTop_toBottomOf="@id/textLeftUp"
-        tools:text="Left Action down" />
+        tools:layout_marginStart="@dimen/trendyol_uicomponents_toolbar_margin_start_side_text"
+        tools:text="Start Action down" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/textMiddle"
@@ -96,7 +99,7 @@
         app:layout_constraintHeight_min="wrap"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
-        tools:text="Right Action" />
+        tools:text="End Action" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/textRightDown"
@@ -108,7 +111,7 @@
         app:layout_constraintEnd_toStartOf="@id/imageRight"
         app:layout_constraintHeight_min="wrap"
         app:layout_constraintTop_toBottomOf="@id/textRightUp"
-        tools:text="Right Action down" />
+        tools:text="End Action down" />
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/imageRight"
@@ -126,8 +129,9 @@
         android:layout_width="10dp"
         android:layout_height="10dp"
         android:src="@drawable/orange_dot"
+        app:layout_constraintEnd_toEndOf="@id/imageRight"
         app:layout_constraintTop_toTopOf="@id/imageRight"
-        app:layout_constraintEnd_toEndOf="@id/imageRight"/>
+        tools:ignore="ImageContrastCheck" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideStart"

--- a/libraries/toolbar/src/main/res/values/attrs.xml
+++ b/libraries/toolbar/src/main/res/values/attrs.xml
@@ -3,24 +3,40 @@
 
     <declare-styleable name="Toolbar">
         <attr name="leftImageDrawable" format="reference" />
+        <attr name="startImageDrawable" format="reference" />
         <attr name="middleImageDrawable" format="reference" />
         <attr name="rightImageDrawable" format="reference" />
+        <attr name="endImageDrawable" format="reference" />
         <attr name="upperLeftText" format="string" />
+        <attr name="upperStartText" format="string" />
         <attr name="lowerLeftText" format="string" />
+        <attr name="lowerStartText" format="string" />
         <attr name="middleText" format="string" />
         <attr name="upperRightText" format="string" />
+        <attr name="upperEndText" format="string" />
         <attr name="lowerRightText" format="string" />
+        <attr name="lowerEndText" format="string" />
         <attr name="toolbarBackground" format="reference" />
         <attr name="upperLeftTextMarginStart" format="dimension" />
+        <attr name="upperStartTextMarginStart" format="dimension" />
         <attr name="lowerLeftTextMarginStart" format="dimension" />
+        <attr name="lowerStartTextMarginStart" format="dimension" />
         <attr name="upperRightTextMarginEnd" format="dimension" />
+        <attr name="upperEndTextMarginEnd" format="dimension" />
         <attr name="lowerRightTextMarginEnd" format="dimension" />
+        <attr name="lowerEndTextMarginEnd" format="dimension" />
         <attr name="rightImageDrawableMarginEnd" format="dimension" />
+        <attr name="endImageDrawableMarginEnd" format="dimension" />
         <attr name="rightImageDrawableVerticalMargin" format="dimension" />
+        <attr name="endImageDrawableVerticalMargin" format="dimension" />
         <attr name="enableDotPoint" format="boolean" />
         <attr name="leftImageDrawableMarginStart" format="dimension" />
+        <attr name="startImageDrawableMarginStart" format="dimension" />
         <attr name="hideLeftImage" format="boolean" />
+        <attr name="hideStartImage" format="boolean" />
         <attr name="leftImageContentDescription" format="string" />
+        <attr name="startImageContentDescription" format="string" />
         <attr name="rightImageContentDescription" format="string" />
+        <attr name="endImageContentDescription" format="string" />
     </declare-styleable>
 </resources>

--- a/libraries/toolbar/src/main/res/values/dimens.xml
+++ b/libraries/toolbar/src/main/res/values/dimens.xml
@@ -2,6 +2,6 @@
 <resources>
 
     <dimen name="trendyol_uicomponents_toolbar_margin_outer">8dp</dimen>
-    <dimen name="trendyol_uicomponents_toolbar_margin_left_side_text">24dp</dimen>
+    <dimen name="trendyol_uicomponents_toolbar_margin_start_side_text">24dp</dimen>
     <dimen name="trendyol_uicomponents_toolbar_padding">8dp</dimen>
 </resources>

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         versionName = "1.0"
     }
     buildTypes {
-        getByName<com.android.build.gradle.internal.dsl.BuildType>("release") {
+        release {
             isMinifyEnabled = false
             setProguardFiles(
                 mutableListOf(
@@ -23,6 +23,9 @@ android {
                     "proguard-rules.pro"
                 )
             )
+        }
+        all {
+            isPseudoLocalesEnabled = true
         }
     }
 

--- a/sample/src/main/java/com/trendyol/uicomponents/ToolbarActivity.kt
+++ b/sample/src/main/java/com/trendyol/uicomponents/ToolbarActivity.kt
@@ -19,7 +19,7 @@ class ToolbarActivity : AppCompatActivity() {
         setUpToolbar3()
         setUpToolbar4()
 
-        binding.toolbar.leftImageClickListener = { onBackPressed() }
+        binding.toolbar.startImageClickListener = { onBackPressed() }
     }
 
     private fun setUpToolbar3() {
@@ -40,18 +40,21 @@ class ToolbarActivity : AppCompatActivity() {
             upperRightTextClickListener = { showToast("toolbar3.upperRightTextClickListener") }
             middleTextClickListener = { showToast("toolbar3.middleTextClickListener") }
             leftImageClickListener = { showToast("toolbar3.leftImageClickListener") }
-            rightImageClickListener = { showToast("toolbar3.rightImageClickListener") }
+            rightImageClickListener = {
+                viewState = viewState.copy(enableDotPoint = viewState.enableDotPoint.not())
+                showToast("toolbar3.rightImageClickListener")
+            }
         }
     }
 
     private fun setUpToolbar4() {
         with(binding.toolbar4) {
-            lowerLeftTextClickListener = { showToast("toolbar4.lowerLeftTextClickListener") }
-            upperLeftTextClickListener = { showToast("toolbar4.upperLeftTextClickListener") }
-            lowerRightTextClickListener = { showToast("toolbar4.lowerRightTextClickListener") }
-            upperRightTextClickListener = { showToast("toolbar4.upperRightTextClickListener") }
-            leftImageClickListener = { showToast("toolbar4.leftImageClickListener") }
-            rightImageClickListener = { showToast("toolbar4.rightImageClickListener") }
+            lowerStartTextClickListener = { showToast("toolbar4.lowerStartTextClickListener") }
+            upperStartTextClickListener = { showToast("toolbar4.upperStartTextClickListener") }
+            lowerEndTextClickListener = { showToast("toolbar4.lowerEndTextClickListener") }
+            upperEndTextClickListener = { showToast("toolbar4.upperEndTextClickListener") }
+            startImageClickListener = { showToast("toolbar4.startImageClickListener") }
+            endImageClickListener = { showToast("toolbar4.endImageClickListener") }
         }
     }
 

--- a/sample/src/main/res/drawable/ic_info_black_24.xml
+++ b/sample/src/main/res/drawable/ic_info_black_24.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z" />
+</vector>

--- a/sample/src/main/res/layout/activity_toolbar.xml
+++ b/sample/src/main/res/layout/activity_toolbar.xml
@@ -34,7 +34,7 @@
                 android:textAlignment="center" />
 
             <androidx.appcompat.widget.AppCompatTextView
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Toolbar height: actionBarSize"
                 tools:ignore="HardcodedText" />
@@ -59,7 +59,7 @@
                 android:textAlignment="center" />
 
             <androidx.appcompat.widget.AppCompatTextView
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Toolbar height: 100dp, custom background with upper left text"
                 tools:ignore="HardcodedText" />
@@ -85,7 +85,7 @@
                 android:textAlignment="center" />
 
             <androidx.appcompat.widget.AppCompatTextView
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Toolbar height: wrap_content, programmatically set"
                 tools:ignore="HardcodedText" />
@@ -109,7 +109,7 @@
                 android:textAlignment="center" />
 
             <androidx.appcompat.widget.AppCompatTextView
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Toolbar height: actionBarSize, set with attributes"
                 tools:ignore="HardcodedText" />
@@ -119,14 +119,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
                 android:elevation="8dp"
-                app:lowerLeftText="lowerLeftText"
-                app:lowerRightText="lowerRightText"
-                app:rightImageContentDescription="Right Arrow"
-                app:rightImageDrawable="@drawable/trendyol_uicomponents_toolbar_arrow_back"
-                app:rightImageDrawableMarginEnd="@dimen/trendyol_uicomponents_toolbar_margin_outer"
+                app:lowerStartText="lowerStartText"
+                app:lowerEndText="lowerEndText"
+                app:endImageContentDescription="End Arrow"
+                app:endImageDrawable="@drawable/ic_info_black_24"
+                app:endImageDrawableMarginEnd="@dimen/trendyol_uicomponents_toolbar_margin_outer"
                 app:toolbarBackground="?attr/colorPrimary"
-                app:upperLeftText="upperLeftText"
-                app:upperRightText="upperRightText" />
+                app:upperStartText="upperStartText"
+                app:upperEndText="upperEndText" />
 
             <View
                 android:layout_width="match_parent"
@@ -142,7 +142,7 @@
                 android:textAlignment="center" />
 
             <androidx.appcompat.widget.AppCompatTextView
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Toolbar height: actionBarSize, upperLeftTextMarginStart: 8dp"
                 tools:ignore="HardcodedText" />
@@ -173,9 +173,9 @@
                 android:textAlignment="center" />
 
             <androidx.appcompat.widget.AppCompatTextView
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Toolbar height: actionBarSize, hideLeftImage: true, upperLeftTextMarginStart: 8dp, upperRightTextMarginEnd: 8dp"
+                android:text="Toolbar height: actionBarSize, hideLeftImage: true, upperLeftTextMarginStart: 8dp, upperRightTextMarginEnd: 8dp, upperLeftTextMarginStart: 8dp"
                 tools:ignore="HardcodedText" />
 
             <com.trendyol.uicomponents.toolbar.Toolbar


### PR DESCRIPTION
Updated Toolbar component to fix RTL errors and support namings with "start-end" instead of "left-right".

Created new attributes, new constructor  for `ToolbarViewState` and new click listeners with new namings. Had to kept existing resource id's because they can be accessible 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

- Fix `textLeftUp` and `textLeftDown` alignment bug when RTL enabled.
- Deprecate existing constructor of `ToolbarViewState` with new namings.
- Update `Toolbar` to add new named click listeners and attributes.
- Update `README`.
- Set component version to toolbar-2.2.0.
- Enable publishing sources and java doc.
- Update `ToolbarActivity` by using new attribute and click listener names on `toolbar4`.

## Motivation and Context

We already updated this view before to support RTL but namings were confusing, in order to fix that, we renamed fields and attributes.

## How Has This Been Tested?

Tested on emulator.

## Screenshots (if appropriate):
<img src="https://github.com/Trendyol/android-ui-components/assets/11295209/1c28a7a5-d7a4-4e5a-9282-5716d84fd4de" width="240px">
<img src="https://github.com/Trendyol/android-ui-components/assets/11295209/41abaf7d-3955-475d-a0ab-021cf8bc40f6" width="240px">

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
