### PR TITLE
MPDP-8274 | Add null check to finger count change

### DIFF
--- a/libraries/image-slider/src/main/java/com/trendyol/uicomponents/imageslider/CVFloatingZoomView.kt
+++ b/libraries/image-slider/src/main/java/com/trendyol/uicomponents/imageslider/CVFloatingZoomView.kt
@@ -261,10 +261,12 @@ class CVFloatingZoomView(
     }
 
     private fun onFingerCountChange(event: MotionEvent, newstate: FingerSwapState) {
-        initialPoint!!.set(
-            initialPoint!!.x - (lastCenter!!.x - currentCenter!!.x),
-            initialPoint!!.y - (lastCenter!!.y - currentCenter!!.y)
-        )
+        if (lastCenter != null && currentCenter != null && initialPoint != null) {
+            initialPoint!!.set(
+                initialPoint!!.x - (lastCenter!!.x - currentCenter!!.x),
+                initialPoint!!.y - (lastCenter!!.y - currentCenter!!.y)
+            )
+        }
         lastCenter = currentCenter
         remainingFingerIndex =
             1 - (event.action and ACTION_POINTER_INDEX_MASK shr ACTION_POINTER_INDEX_SHIFT)


### PR DESCRIPTION
## Description
This MR addresses a potential crash in CVFloatingZoomView related to null pointer exceptions involving lastCenter and initialPoint during multi-touch interactions. Although I was unable to reproduce the crash locally, analysis of the crash logs and code indicates that a rapid change in finger count or an interrupted initialization sequence could result in these variables being null when accessed, leading to a crash.
To mitigate this, I have added null checks before performing operations on these variables in the relevant methods. This ensures that, even in rare edge cases, the app will not crash and the zoom view will continue to provide a seamless user experience. Since the zoom functionality already works smoothly for typical usage, this is a defensive fix to cover unexpected scenarios. 
